### PR TITLE
PP-682 Integrating card store with service and resource layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,50 @@ The service provides an API that could be accessed to retrieve card information 
 
 ## Card data
 The data for this service would need to be sourced externally from relevant providers. 
-The service currently supports data provided by; 
+The service currently supports data provided by: 
 
 - Worldpay 
 - Discover 
 
-For the service to built run the relevant data from the supported providers would need to be placed in the `data` 
-directory in csv format.
+For the service to built and run the relevant data from the supported providers would need to be placed in the appropriate
+location under the `data` folder as follows:
 
+### Worldpay
+
+Location: /data/sources/worldpay
+Format: csv
+
+* The csv file is expected to have the following structure, as of WordlPay EMIS v19 document
+
+ ```
+ 00!12102015!!!!!!!!!!
+ 05!511949000!511949999!CN!ELECTRON!SAMPLE COMP PLC!GBR!826!D!PE000!XE000!Y
+ 99!1!!!!!!!!!!
+ ```
+ 
+ * Legend:
+     * `00` - header
+     * `05` - data record 
+     * `99` - EOF
+
+### Discover
+
+Location: /data/sources/discover
+Format: csv
+
+* Since the data from discover is in pdf format, the services expects it to be converted into a csv format. The csv file is
+ expected to have the following structure.
+
+ ```
+ 01,START,END,TYPE,BRAND
+ 02,12345678,12345679,C,DISCOVER
+ 09
+ ```
+ * Legend:
+     * `01` - header
+     * `02` - data record
+     * `09` - EOF
+   
 ## API
 
 ### GET /v1/api/card/{card_number}

--- a/src/main/java/uk/gov/pay/card/db/CardInformationStore.java
+++ b/src/main/java/uk/gov/pay/card/db/CardInformationStore.java
@@ -6,9 +6,9 @@ import uk.gov.pay.card.model.CardInformation;
 import java.util.Optional;
 
 public interface CardInformationStore {
-    void initialiseCardInformation() throws Exception;
+    int CARD_RANGE_LENGTH = 9;
 
-    int getStoreSize();
+    void initialiseCardInformation() throws Exception;
 
     void put(CardInformation cardInformation);
 

--- a/src/main/java/uk/gov/pay/card/db/InfinispanCardInformationStore.java
+++ b/src/main/java/uk/gov/pay/card/db/InfinispanCardInformationStore.java
@@ -33,14 +33,9 @@ public class InfinispanCardInformationStore implements CardInformationStore {
     }
 
     @Override
-    public int getStoreSize() {
-        return cardIdStore.size();
-    }
-
-    @Override
     public void put(CardInformation cardInformation) {
         String key = cardInformation.getMin() + "-" + cardInformation.getMax();
-        cardInformation.updateRangeLength(9);
+        cardInformation.updateRangeLength(CARD_RANGE_LENGTH);
         cardIdStore.putIfAbsent(key, cardInformation);
     }
 

--- a/src/main/java/uk/gov/pay/card/model/CardInformationResponse.java
+++ b/src/main/java/uk/gov/pay/card/model/CardInformationResponse.java
@@ -13,10 +13,10 @@ public class CardInformationResponse {
     @JsonProperty("label")
     private String label;
 
-    public CardInformationResponse(String brand, String type, String label) {
-        this.brand = brand;
-        this.type = type;
-        this.label = label;
+    public CardInformationResponse(CardInformation cardData) {
+        this.brand = cardData.getBrand();
+        this.label = cardData.getLabel();
+        this.type = cardData.getType();
     }
 
     public String getBrand() {

--- a/src/main/java/uk/gov/pay/card/resources/CardIdResource.java
+++ b/src/main/java/uk/gov/pay/card/resources/CardIdResource.java
@@ -1,22 +1,38 @@
 package uk.gov.pay.card.resources;
 
+import uk.gov.pay.card.model.CardInformation;
 import uk.gov.pay.card.model.CardInformationResponse;
+import uk.gov.pay.card.service.CardService;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
 public class CardIdResource {
 
+    CardService cardService;
+
+    public CardIdResource(CardService cardService) {
+        this.cardService = cardService;
+    }
+
     @GET
     @Path("/v1/api/card/{card_number}")
     @Produces(APPLICATION_JSON)
     public Response cardInformation(@PathParam("card_number") String cardNumber) {
-        return Response.ok(new CardInformationResponse("visa", "debit", "visa")).build();
+        Optional<CardInformation> cardInformation = cardService.getCardInformation(cardNumber);
+
+        return cardInformation.map(cardData -> {
+            CardInformationResponse cardInformationResponse = new CardInformationResponse(cardData);
+            return Response.ok(cardInformationResponse).build();
+
+        }).orElse(Response.status(404).build());
+
     }
 }

--- a/src/main/java/uk/gov/pay/card/service/CardService.java
+++ b/src/main/java/uk/gov/pay/card/service/CardService.java
@@ -1,10 +1,19 @@
 package uk.gov.pay.card.service;
 
+import uk.gov.pay.card.db.CardInformationStore;
 import uk.gov.pay.card.model.CardInformation;
+
+import java.util.Optional;
 
 public class CardService {
 
-    public CardInformation getCardInformation(String cardNumber) {
-        return null;
+    private final CardInformationStore cardInformationStore;
+
+    public CardService(CardInformationStore cardInformationStore) {
+        this.cardInformationStore = cardInformationStore;
+    }
+
+    public Optional<CardInformation> getCardInformation(String cardNumber) {
+        return cardInformationStore.find(cardNumber.substring(0, CardInformationStore.CARD_RANGE_LENGTH));
     }
 }

--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.card.it.resources;
+
+import com.jayway.restassured.response.ValidatableResponse;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.card.app.CardApi;
+import uk.gov.pay.card.app.config.CardConfiguration;
+
+import java.io.IOException;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.http.ContentType.JSON;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.hamcrest.core.Is.is;
+
+
+public class CardIdResourceITest {
+
+    @Rule
+    public DropwizardAppRule<CardConfiguration> app = new DropwizardAppRule<>(
+            CardApi.class
+            , resourceFilePath("config/config.yaml")
+            , config("worldpayDataLocation", "data/sources/worldpay/")
+            , config("discoverDataLocation", "data/sources/discover/"));
+
+    @Test
+    public void shouldFindDiscoverCardInformation() throws IOException {
+
+        getCardInformation("6221267457963485")
+                .statusCode(200)
+                .contentType(JSON)
+                .body("brand", is("UNIONPAY"))
+                .body("label", is("UNIONPAY"))
+                .body("type", is("CD"));
+
+    }
+
+    @Test
+    public void shouldFindWorldpayCardInformation() throws IOException {
+
+        getCardInformation("4000020004598361")
+                .statusCode(200)
+                .contentType(JSON)
+                .body("brand", is("VISA CREDIT"))
+                .body("label", is("VISA CREDIT"))
+                .body("type", is("C"));
+
+    }
+
+    @Test
+    public void shouldReturn404WhenCardInformationNotFoud() {
+        getCardInformation("8282382383829393")
+                .statusCode(404);
+    }
+
+    private ValidatableResponse getCardInformation(String cardNumber) {
+        return given().port(app.getLocalPort())
+                .get(String.format("/v1/api/card/%s", cardNumber))
+                .then();
+    }
+}

--- a/src/test/java/uk/gov/pay/card/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/card/service/CardServiceTest.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.card.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.card.db.CardInformationStore;
+import uk.gov.pay.card.model.CardInformation;
+
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CardServiceTest {
+
+    private CardInformationStore cardInformationStore = mock(CardInformationStore.class);
+
+    private CardService cardService;
+
+    @Before
+    public void setup() {
+        cardService = new CardService(cardInformationStore);
+    }
+
+    @Test
+    public void shouldStripTheCardNumberTo9DigitsForBingRangeLookup() {
+        CardInformation expectedCardInformation = new CardInformation("visa", "D", "visa", 11000L, 13000L);
+        when(cardInformationStore.find("123456789")).thenReturn(Optional.of(expectedCardInformation));
+
+        Optional<CardInformation> cardInformation = cardService.getCardInformation("1234567890123456");
+
+        assertThat(expectedCardInformation, is(cardInformation.get()));
+        verify(cardInformationStore).find("123456789");
+    }
+
+}


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
 * Integrated the card information store with the service and resource
   layers and added the respective unit tests
 * Refactored the `CardApi` to manually inject the service and the store
 * README.md updated with the expected data file locations

with @PauloPortugal

## HOW 
_Steps to test or reproduce:_
Run msl up in the cardid project
Access https://cardid.pymnt.localdomain/v1/api/card/[card-number]

## WHO
_Who should review this pull request:_

- [x] Developers
- [ ] WebOps

