### PR TITLE
PP-682 Adding mocked american express data

### DIFF
--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
@@ -63,6 +63,18 @@ public class CardIdResourceITest {
     }
 
     @Test
+    public void shouldFindAmexCardInformation() throws IOException {
+
+        getCardInformation("371449635398431")
+                .statusCode(200)
+                .contentType(JSON)
+                .body("brand", is("american-express"))
+                .body("label", is("AMERICAN EXPRESS"))
+                .body("type", is("C"));
+
+    }
+
+    @Test
     public void shouldReturn404WhenCardInformationNotFoud() {
         getCardInformation("8282382383829393")
                 .statusCode(404);


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
* We still don't have information on the amex BIN ranges.
Therefore we are creating mock data and marking all amex cards
as credit cards.

## HOW 
_Steps to test or reproduce:_

## WHO
_Who should review this pull request:_

- [x] Developers