### PR TITLE
PP-682 Configuring heap size

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -4,4 +4,4 @@ if [ "${ENABLE_NEWRELIC}" == "yes" ]; then
   NEWRELIC_JVM_FLAG="-javaagent:/app/newrelic/newrelic.jar"
 fi
 
-java ${NEWRELIC_JVM_FLAG} -jar *-allinone.jar server *.yaml
+java -Xms1500m -Xmx1500m ${NEWRELIC_JVM_FLAG} -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
 * Please merge https://github.com/alphagov/pay-scripts/pull/233 before merging this.
 * As we load all cardid data into memory, the whole data set takes
   650MB. With out heap settings the service gets a bit busy with
   major GCs. Therefore setting the Xmx and Xms to allocate a sufficient
   amount of memory for the service.

## HOW 
_Steps to test or reproduce:_

## WHO
_Who should review this pull request:_

- [x] Developers
- [x] WebOps

## Related PRs

branch | PR
------ | ------
increase_memory_limit_for_cardid | https://github.com/alphagov/pay-scripts/pull/233
