### PR TITLE
Using RangeSet instead of Infinispan

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
             <version>${infinispan.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.6.4</version>

--- a/src/main/java/uk/gov/pay/card/app/CardApi.java
+++ b/src/main/java/uk/gov/pay/card/app/CardApi.java
@@ -7,7 +7,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.card.app.config.CardConfiguration;
 import uk.gov.pay.card.db.CardInformationStore;
-import uk.gov.pay.card.db.InfinispanCardInformationStore;
+import uk.gov.pay.card.db.RangeSetCardInformationStore;
 import uk.gov.pay.card.db.loader.BinRangeDataLoader;
 import uk.gov.pay.card.healthcheck.Ping;
 import uk.gov.pay.card.managed.CardInformationStoreManaged;
@@ -16,7 +16,7 @@ import uk.gov.pay.card.resources.HealthCheckResource;
 import uk.gov.pay.card.service.CardService;
 
 import static java.util.Arrays.asList;
-import static uk.gov.pay.card.db.loader.BinRangeDataLoader.*;
+import static uk.gov.pay.card.db.loader.BinRangeDataLoader.BinRangeDataLoaderFactory;
 
 public class CardApi extends Application<CardConfiguration> {
 
@@ -53,6 +53,6 @@ public class CardApi extends Application<CardConfiguration> {
 
         BinRangeDataLoader testCardsBinRangeDataLoader = BinRangeDataLoaderFactory.testCards(configuration.getTestCardDataLocation());
 
-        return new InfinispanCardInformationStore(asList(worldPayBinRangeDataLoader, discoverBinRangeDataLoader, testCardsBinRangeDataLoader));
+        return new RangeSetCardInformationStore(asList(worldPayBinRangeDataLoader, discoverBinRangeDataLoader, testCardsBinRangeDataLoader));
     }
 }

--- a/src/main/java/uk/gov/pay/card/db/RangeSetCardInformationStore.java
+++ b/src/main/java/uk/gov/pay/card/db/RangeSetCardInformationStore.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.card.db;
+
+
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import uk.gov.pay.card.db.loader.BinRangeDataLoader;
+import uk.gov.pay.card.model.CardInformation;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public class RangeSetCardInformationStore implements CardInformationStore {
+
+    private final List<BinRangeDataLoader> binRangeLoaders;
+    RangeSet<Long> rangeSet;
+    ConcurrentHashMap<Range, CardInformation> store;
+
+    public RangeSetCardInformationStore(List<BinRangeDataLoader> binRangeLoaders) {
+        this.binRangeLoaders = binRangeLoaders;
+        rangeSet = TreeRangeSet.create();
+        store = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void initialiseCardInformation() throws Exception {
+        for (BinRangeDataLoader loader : binRangeLoaders) {
+            loader.loadDataTo(this);
+        }
+    }
+
+    @Override
+    public void put(CardInformation cardInformation) {
+        cardInformation.updateRangeLength(CARD_RANGE_LENGTH);
+        cardInformation.transformBrand();
+        Range<Long> range = Range.closed(cardInformation.getMin(), cardInformation.getMax());
+        rangeSet.add(range);
+        store.put(range, cardInformation);
+    }
+
+    @Override
+    public Optional<CardInformation> find(String prefix) {
+        Range<Long> longRange = rangeSet.rangeContaining(Long.valueOf(prefix));
+        if(longRange != null) {
+            return Optional.ofNullable(store.get(longRange));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void destroy() {
+        rangeSet.clear();
+        store.clear();
+    }
+
+    public String toString() {
+        return "keys=" + store.size();
+    }
+}

--- a/src/test/java/uk/gov/pay/card/bench/RageSetCardInformationStoreBenchmark.java
+++ b/src/test/java/uk/gov/pay/card/bench/RageSetCardInformationStoreBenchmark.java
@@ -1,0 +1,77 @@
+package uk.gov.pay.card.bench;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import uk.gov.pay.card.db.CardInformationStore;
+import uk.gov.pay.card.db.InfinispanCardInformationStore;
+import uk.gov.pay.card.db.RangeSetCardInformationStore;
+import uk.gov.pay.card.db.loader.BinRangeDataLoader;
+import uk.gov.pay.card.model.CardInformation;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static uk.gov.pay.card.db.loader.BinRangeDataLoader.BinRangeDataLoaderFactory;
+
+/***
+ * To run this Benchmark against the whole of worldpay BIN range data set;
+ * - Make a copy of the worldpay data into the test/rsoureces/ folder.
+ * - Change the name of the file to load in this benchmark (in the setup()) method.
+ * - You would have to replace the existing test card prefixes with some new prefixes.
+ * - And then run the benchmark.
+ */
+@State(Scope.Benchmark)
+public class RageSetCardInformationStoreBenchmark {
+
+    private CardInformationStore cardInformationStore;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        URL url = this.getClass().getResource("/worldpay/");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        cardInformationStore = new RangeSetCardInformationStore(singletonList(worldpayBinRangeLoader));
+        cardInformationStore.initialiseCardInformation();
+    }
+
+    @Param({
+            "511226112", "511226113", "511226114", "511226115", "511226116", "511226117", "511226118", "511226119", "511226120",
+            "511226122", "511226123", "511226124", "511226125", "511226126", "511226127", "511226128", "511226129", "511226130",
+            "511948111", "511948112", "511948113", "511948114", "511948115", "511948116", "511948117", "511948118", "511948119"
+    })
+    public String cardIdPrefix;
+
+    @Benchmark
+    public void runBenchmark(Blackhole blackhole) {
+        Optional<CardInformation> cardInformation = cardInformationStore.find(cardIdPrefix);
+        cardInformation.orElseThrow(() -> new RuntimeException("card information not found"));
+        blackhole.consume(cardInformation);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+                .warmupIterations(5)
+                .measurementIterations(20)
+                .forks(1)
+                .threads(5)
+                .include(RageSetCardInformationStoreBenchmark.class.getSimpleName())
+                .timeUnit(TimeUnit.MICROSECONDS)
+                .mode(Mode.AverageTime)
+                .build();
+
+        new Runner(options).run();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        cardInformationStore.destroy();
+    }
+
+}

--- a/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
+++ b/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
@@ -1,0 +1,98 @@
+package uk.gov.pay.card.db;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.card.db.loader.BinRangeDataLoader;
+import uk.gov.pay.card.model.CardInformation;
+
+import java.net.URL;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.card.db.loader.BinRangeDataLoader.BinRangeDataLoaderFactory;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RangeSetCardInformationStoreTest {
+
+    CardInformationStore cardInformationStore;
+
+    @After
+    public void tearDown() {
+        cardInformationStore.destroy();
+    }
+
+    @Test
+    public void shouldUseLoadersToInitialiseData() throws Exception {
+        BinRangeDataLoader mockBinRangeLoader = mock(BinRangeDataLoader.class);
+
+        cardInformationStore = new RangeSetCardInformationStore(asList(mockBinRangeLoader));
+        cardInformationStore.initialiseCardInformation();
+
+        verify(mockBinRangeLoader).loadDataTo(cardInformationStore);
+    }
+
+    @Test
+    public void shouldFindCardInformationForCardIdPrefix() throws Exception {
+        URL url = this.getClass().getResource("/worldpay/");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        cardInformationStore = new RangeSetCardInformationStore(asList(worldpayBinRangeLoader));
+        cardInformationStore.initialiseCardInformation();
+
+        Optional<CardInformation> cardInformation = cardInformationStore.find("511948121");
+        assertTrue(cardInformation.isPresent());
+        assertThat(cardInformation.get().getBrand(), is("electron"));
+        assertThat(cardInformation.get().getType(), is("D"));
+        assertThat(cardInformation.get().getLabel(), is("ELECTRON"));
+    }
+
+    @Test
+    public void shouldFindCardInformationWithRangeLengthLessThan9digits() throws Exception {
+        URL url = this.getClass().getResource("/worldpay-6-digits/");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        cardInformationStore = new RangeSetCardInformationStore(asList(worldpayBinRangeLoader));
+        cardInformationStore.initialiseCardInformation();
+
+        Optional<CardInformation> cardInformation = cardInformationStore.find("511226764");
+        assertTrue(cardInformation.isPresent());
+        assertThat(cardInformation.get().getBrand(), is("electron"));
+        assertThat(cardInformation.get().getType(), is("D"));
+        assertThat(cardInformation.get().getLabel(), is("ELECTRON"));
+    }
+
+    @Test
+    public void put_shouldUpdateRangeLengthTo9Digits() {
+        BinRangeDataLoader mockBinRangeLoader = mock(BinRangeDataLoader.class);
+        CardInformation cardInformation = mock(CardInformation.class);
+
+        when(cardInformation.getMin()).thenReturn(1L);
+        when(cardInformation.getMax()).thenReturn(19L);
+
+        cardInformationStore = new RangeSetCardInformationStore(asList(mockBinRangeLoader));
+        cardInformationStore.put(cardInformation);
+
+        verify(cardInformation).updateRangeLength(9);
+    }
+
+    @Test
+    public void shouldTransformMastercardBrand() throws Exception {
+        URL url = this.getClass().getResource("/worldpay/");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+
+        cardInformationStore = new RangeSetCardInformationStore(asList(worldpayBinRangeLoader));
+        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
+
+        Optional<CardInformation> cardInformation = cardInformationStore.find("511226111");
+
+        assertTrue(cardInformation.isPresent());
+        assertThat(cardInformation.get().getBrand(), is("master-card"));
+
+    }
+}


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
* While infinispan gives a nice DSL to query for ranges, its also
  not the fastest option. Using `RangeSet` to set the ranges and using
  a separate ConcurrentHashmap to store card information seem to be
  performing faster based on the tests and benchmarks.
* The benchmarks show a 14.910 us/op (average) on the Infinispan approach while
  the `RangeSet` based approach comes up with 0.018 us/op (average)
* The `RangeSet` only has the applicable range and the actual data are stored in a
  ConcurrentHashmap with the Range as a key. `Range` as a key suffice the requirement
  for a key with its implementation of hashcode() and equals() methods.
* Once this is merged, there'll be a separate PR that removes the `InfinispanCardInformationStore`

## HOW 
_Steps to test or reproduce:_
- To see the improvement in performance, run the `RageSetCardInformationStoreBenchmark` and compare the results by running `InfinispanCardInformationStoreBenchmark`. Both bench marks can be run from your IDE
- Also run the unit test to see that it functions the same way as the Infinispan based implementation on the same test data set.

## WHO
_Who should review this pull request:_

- [x] Developers
- [ ] WebOps

