### PR TITLE
PP-1386 Using a histogram instead of a gauge

### DIFF
--- a/src/main/java/uk/gov/pay/card/filters/LoggingFilter.java
+++ b/src/main/java/uk/gov/pay/card/filters/LoggingFilter.java
@@ -49,7 +49,7 @@ public class LoggingFilter implements Filter {
             logger.info(format("[%s] - %s to %s ended - total time %dms", requestId, requestMethod, requestURL,
                     elapsed));
             stopwatch.stop();
-            metricsRegistry.histogram(requestURL).update(elapsed);
+            metricsRegistry.histogram("response-times").update(elapsed);
         }
     }
 

--- a/src/main/java/uk/gov/pay/card/filters/LoggingFilter.java
+++ b/src/main/java/uk/gov/pay/card/filters/LoggingFilter.java
@@ -49,7 +49,7 @@ public class LoggingFilter implements Filter {
             logger.info(format("[%s] - %s to %s ended - total time %dms", requestId, requestMethod, requestURL,
                     elapsed));
             stopwatch.stop();
-            metricsRegistry.register(requestURL, (Gauge<Long>) () -> elapsed);
+            metricsRegistry.histogram(requestURL).update(elapsed);
         }
     }
 

--- a/src/test/java/uk/gov/pay/card/filters/LoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/card/filters/LoggingFilterTest.java
@@ -7,6 +7,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -52,10 +53,15 @@ public class LoggingFilterTest {
     @Mock
     MetricRegistry mockMetricRegistry;
 
+    @Mock
+    private Histogram mockHistogram;
+
     private Appender<ILoggingEvent> mockAppender;
 
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+
 
     @Before
     public void setup() {
@@ -63,6 +69,8 @@ public class LoggingFilterTest {
         Logger root = (Logger) LoggerFactory.getLogger(LoggingFilter.class);
         mockAppender = mockAppender();
         root.addAppender(mockAppender);
+
+        when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
     }
 
     @Test
@@ -147,7 +155,7 @@ public class LoggingFilterTest {
 
         loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(mockMetricRegistry).register(eq(requestUrl), isA(Gauge.class));
+        verify(mockHistogram).update(anyLong());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

 - To use a dropwizard gauge, the value needs to be provided by something else.
   You can't seem to update a gauge manually. It throws an exception if you try to
   do that. Therefore using a histogram instead. We will be ignoring, some metrics
   emmitted by the histogram though.

with @simad