### PR TITLE
PP-1753 Upgraded project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,9 @@
     <artifactId>pay-cardid</artifactId>
 
     <properties>
-        <dropwizard.version>0.8.1</dropwizard.version>
-        <jersey2.version>2.17</jersey2.version>
-        <mockserver.version>3.9.17</mockserver.version>
+        <dropwizard.version>1.0.6</dropwizard.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <infinispan.version>8.2.2.Final</infinispan.version>
-        <jmh.version>1.10.3</jmh.version>
+        <jmh.version>1.17.5</jmh.version>
     </properties>
 
     <dependencies>
@@ -33,17 +30,32 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>21.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.6.7</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.6.7</version>
+            <version>2.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>2.25.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-jaxb</artifactId>
+            <version>2.25.1</version>
         </dependency>
 
         <!-- testing -->
@@ -56,7 +68,7 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>2.4.0</version>
+            <version>2.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -91,12 +103,12 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
         </dependency>
     </dependencies>
 

--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
@@ -23,37 +23,34 @@ public class CardIdResourceITest {
     public DropwizardAppRule<CardConfiguration> app = new DropwizardAppRule<>(
             CardApi.class
             , resourceFilePath("config/config.yaml")
+            , config("server.applicationConnectors[0].port", "9800")
+            , config("server.adminConnectors[0].port", "9801")
             , config("worldpayDataLocation", "data/sources/worldpay/")
             , config("discoverDataLocation", "data/sources/discover/")
             , config("testCardDataLocation", "data/sources/test-cards/"));
 
     @Test
     public void shouldFindDiscoverCardInformation() throws IOException {
-
         getCardInformation("6221267457963485")
                 .statusCode(200)
                 .contentType(JSON)
                 .body("brand", is("unionpay"))
                 .body("label", is("UNIONPAY"))
                 .body("type", is("CD"));
-
     }
 
     @Test
     public void shouldFindTestCardInformation() throws IOException {
-
         getCardInformation("4242424242424242")
                 .statusCode(200)
                 .contentType(JSON)
                 .body("brand", is("visa"))
                 .body("label", is("VISA CREDIT"))
                 .body("type", is("C"));
-
     }
 
     @Test
     public void shouldFindWorldpayCardInformation() throws IOException {
-
         getCardInformation("4000020004598361")
                 .statusCode(200)
                 .contentType(JSON)
@@ -65,7 +62,6 @@ public class CardIdResourceITest {
 
     @Test
     public void shouldFindAmexCardInformation() throws IOException {
-
         getCardInformation("371449635398431")
                 .statusCode(200)
                 .contentType(JSON)
@@ -82,7 +78,6 @@ public class CardIdResourceITest {
     }
 
     private ValidatableResponse getCardInformation(String cardNumber) {
-        System.out.println("-------------------------->" + app.getLocalPort());
         return given().port(app.getLocalPort())
                 .contentType(ContentType.JSON)
                 .body(String.format("{\"cardNumber\":%s}", cardNumber))

--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
@@ -82,6 +82,7 @@ public class CardIdResourceITest {
     }
 
     private ValidatableResponse getCardInformation(String cardNumber) {
+        System.out.println("-------------------------->" + app.getLocalPort());
         return given().port(app.getLocalPort())
                 .contentType(ContentType.JSON)
                 .body(String.format("{\"cardNumber\":%s}", cardNumber))


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- Upgraded the following project dependencies to their latest stable version:
  - `Dropwizard` from version `0.8.1` to `1.0.6`.
  - `guava` from version `19.0` to `21.0`
  - `jackson-datatype-jsr310` from version `2.6.7` to `2.8.7`
  - `jackson-annotations` from version `2.6.7` to `2.8.7`
  - `httpclient` from version `4.5.2` to `4.5.3`
  - `jersey-common` from version `2.23.2` to `2.25.1`
  - `jersey-media-jaxb` from version `2.23.2` to `2.25.1`

- The latest version of Dropwizard enforces all config values to be resolved at runtime which caused the integration tests to fail because the `ports` weren't specified. To get around the problem the config entries for `ports` have been overwritten in the tests.

`Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Can not deserialize value of type int from String "${PORT}": not a valid int value`

NOTE: The SourceClear report still shows a medium risk vulnerability in `jersey-common` and `jersey media-jaxb` libraries even in the latest version.

https://app.sourceclear.com/teams/100t11M/scans/1027557