### PR TITLE
PP-1809 Downgrade dropwizard-metrics to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,13 +102,8 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>3.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
-            <version>3.2.0</version>
+            <version>3.1.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## WHAT
- Dropwizard 1.0.6 brings in metrics version 3.1.2. We were
  explicitly pulling in version 3.2.0, which changed the way
  metrics paths are sanitised.
  See https://github.com/dropwizard/metrics/pull/1098.
- By not explicitly pulling in metrics-core (and letting dropwizard
  decide on which version to use) and downgrading graphite-metrics,
  we will go back to a well tested version
- The version of metrics 3.2.1 will be pulled in by the next version
  of dropwizard. This should be safe to use, as the bug which broke
  our metrics has been fixed. Still, would advise some caution
  when upgrading dropwizard again

## HOW 
_Steps to test or reproduce:_


