### PR TITLE
PP-3265 Jenkins jobs converted to use selenium style smoke tests for all

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,8 +55,8 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("cardid", "test", null, false, false)
-        deployEcs("cardid", "test", null, true, true)
+        deploy("cardid", "test", null, false, false, "uk.gov.pay.endtoend.categories.SmokeCardPayments")
+        deployEcs("cardid", "test", null, true, true, "uk.gov.pay.endtoend.categories.SmokeCardPayments")
       }
     }
   }


### PR DESCRIPTION
microservices

Smoke tests have been converted to selenium and now require a category
class being passed to the smoke tests in order to run a specific
suite. If nothing is passed, the default is for all the smoke tests to
run.