### PR TITLE
PP-3937: Upgrade Dropwizard from 1.2.7 to 1.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>pay-cardid</artifactId>
 
     <properties>
-        <dropwizard.version>1.2.7</dropwizard.version>
+        <dropwizard.version>1.2.8</dropwizard.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jmh.version>1.17.5</jmh.version>
         <jackson.version>2.9.4</jackson.version>


### PR DESCRIPTION
## WHAT
This upgrades Jetty from 9.4.10 to 9.4.11
