### PR TITLE
PP-4289_add_prepaid_card_status

### DIFF
--- a/src/main/java/uk/gov/pay/card/db/loader/BinRangeDataLoader.java
+++ b/src/main/java/uk/gov/pay/card/db/loader/BinRangeDataLoader.java
@@ -33,7 +33,8 @@ public class BinRangeDataLoader {
     private static final String WORLDPAY_CORPORATE_CARD_MARKER = "CP";
 
     private static final Function<String[], CardInformation> WORLDPAY_CARD_INFORMATION_EXTRACTOR = entry -> new CardInformation(
-            entry[4], entry[8], entry[4], Long.valueOf(entry[1]), Long.valueOf(entry[2]), WORLDPAY_CORPORATE_CARD_MARKER.equals(entry[3]));
+            entry[4], entry[8], entry[4], Long.valueOf(entry[1]), Long.valueOf(entry[2]),
+            WORLDPAY_CORPORATE_CARD_MARKER.equals(entry[3]), WorldpayPrepaidParser.parse(entry[11]));
 
     private static final Function<String[], CardInformation> DISCOVER_CARD_INFORMATION_EXTRACTOR = entry -> new CardInformation(
             entry[4], entry[3], entry[4], Long.valueOf(entry[1]), Long.valueOf(entry[2]));

--- a/src/main/java/uk/gov/pay/card/db/loader/WorldpayPrepaidParser.java
+++ b/src/main/java/uk/gov/pay/card/db/loader/WorldpayPrepaidParser.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.card.db.loader;
+
+import uk.gov.pay.card.model.PrepaidStatus;
+
+public class WorldpayPrepaidParser {
+
+    public static PrepaidStatus parse(String value) {
+        if ("Y".equals(value)) {
+            return PrepaidStatus.PREPAID;
+        }
+
+        if ("N".equals(value)) {
+            return PrepaidStatus.NOT_PREPAID;
+        }
+
+        return PrepaidStatus.UNKNOWN;
+    }
+}

--- a/src/main/java/uk/gov/pay/card/model/CardInformation.java
+++ b/src/main/java/uk/gov/pay/card/model/CardInformation.java
@@ -15,6 +15,7 @@ public class CardInformation {
     private Long min;
     private Long max;
     private boolean corporate;
+    private PrepaidStatus prepaidStatus;
 
     private static Map<String, String> brandMapping;
 
@@ -32,17 +33,18 @@ public class CardInformation {
         brandMapping = Collections.unmodifiableMap(brands);
     }
 
-    public CardInformation(String brand, String type, String label, Long min, Long max, boolean corporate) {
+    public CardInformation(String brand, String type, String label, Long min, Long max, boolean corporate, PrepaidStatus prepaidStatus) {
         this.brand = brand;
         this.cardType = CardType.of(type);
         this.label = label;
         this.min = min;
         this.max = max;
         this.corporate = corporate;
+        this.prepaidStatus = prepaidStatus;
     }
 
     public CardInformation(String brand, String type, String label, Long min, Long max) {
-        this(brand, type, label, min, max, false);
+        this(brand, type, label, min, max, false, PrepaidStatus.UNKNOWN);
     }
 
     public String getBrand() {
@@ -69,6 +71,10 @@ public class CardInformation {
         return corporate;
     }
 
+    public PrepaidStatus getPrepaidStatus() {
+        return prepaidStatus;
+    }
+
     public void updateRangeLength(int numLength) {
         min = Long.valueOf(format("%-" + numLength + "d", min).replace(" ", "0"));
         max = Long.valueOf(format("%-" + numLength + "d", max).replace(" ", "9"));
@@ -91,7 +97,8 @@ public class CardInformation {
                 cardType == that.cardType &&
                 Objects.equals(label, that.label) &&
                 Objects.equals(min, that.min) &&
-                Objects.equals(max, that.max);
+                Objects.equals(max, that.max) &&
+                Objects.equals(prepaidStatus, that.prepaidStatus);
     }
 
     @Override
@@ -105,6 +112,7 @@ public class CardInformation {
                 "brand='" + brand + '\'' +
                 ", cardType=" + cardType +
                 ", label='" + label + '\'' +
+                ", prepaidStatus='" + prepaidStatus + '\'' +
                 ", min=" + min +
                 ", max=" + max +
                 ", corporate=" + corporate +

--- a/src/main/java/uk/gov/pay/card/model/CardInformationResponse.java
+++ b/src/main/java/uk/gov/pay/card/model/CardInformationResponse.java
@@ -18,11 +18,15 @@ public class CardInformationResponse {
     @JsonProperty("corporate")
     private boolean corporate;
 
+    @JsonProperty("prepaid")
+    private PrepaidStatus prepaidStatus;
+
     public CardInformationResponse(CardInformation cardData) {
         this.brand = cardData.getBrand();
         this.label = cardData.getLabel();
         this.type = cardData.getCardType().getGovUkPayRepresentation();
         this.corporate = cardData.isCorporate();
+        this.prepaidStatus = cardData.getPrepaidStatus();
     }
 
     @Override
@@ -33,12 +37,13 @@ public class CardInformationResponse {
         return corporate == that.corporate &&
                 Objects.equals(brand, that.brand) &&
                 Objects.equals(type, that.type) &&
-                Objects.equals(label, that.label);
+                Objects.equals(label, that.label) &&
+                Objects.equals(prepaidStatus, that.prepaidStatus);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(brand, type, label, corporate);
+        return Objects.hash(brand, type, label, corporate, prepaidStatus);
     }
 
     @Override
@@ -47,7 +52,8 @@ public class CardInformationResponse {
                 "brand='" + brand + '\'' +
                 ", type='" + type + '\'' +
                 ", label='" + label + '\'' +
-                ", corporate=" + corporate +
+                ", corporate=" + corporate + '\'' +
+                ", prepaidStatus=" + prepaidStatus +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/card/model/PrepaidStatus.java
+++ b/src/main/java/uk/gov/pay/card/model/PrepaidStatus.java
@@ -1,0 +1,3 @@
+package uk.gov.pay.card.model;
+
+public enum PrepaidStatus { PREPAID, NOT_PREPAID, UNKNOWN}

--- a/src/test/java/uk/gov/pay/card/db/loader/BinRangeDataLoaderTest.java
+++ b/src/test/java/uk/gov/pay/card/db/loader/BinRangeDataLoaderTest.java
@@ -6,6 +6,7 @@ import org.junit.rules.ExpectedException;
 import uk.gov.pay.card.db.CardInformationStore;
 import uk.gov.pay.card.db.loader.BinRangeDataLoader.BinRangeDataLoaderFactory;
 import uk.gov.pay.card.model.CardInformation;
+import uk.gov.pay.card.model.PrepaidStatus;
 
 import java.net.URL;
 
@@ -81,7 +82,7 @@ public class BinRangeDataLoaderTest {
         CardInformationStore cardInformationStore = mock(CardInformationStore.class);
         worldpayBinRangeLoader.loadDataTo(cardInformationStore);
 
-        CardInformation expectedCardInformation = new CardInformation("ELECTRON", "D", "ELECTRON", 511226111L, 511226200L);
+        CardInformation expectedCardInformation = new CardInformation("ELECTRON", "D", "ELECTRON", 511226111L, 511226200L, false, PrepaidStatus.PREPAID);
         verify(cardInformationStore).put(expectedCardInformation);
     }
 }

--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
@@ -34,6 +34,7 @@ public class CardIdResourceITest {
                 .body("brand", is("unionpay"))
                 .body("label", is("UNIONPAY"))
                 .body("type", is("CD"))
+                .body("prepaid", is("UNKNOWN"))
                 .body("corporate", is(false));
     }
 
@@ -45,6 +46,7 @@ public class CardIdResourceITest {
                 .body("brand", is("visa"))
                 .body("label", is("VISA CREDIT"))
                 .body("type", is("C"))
+                .body("prepaid", is("NOT_PREPAID"))
                 .body("corporate", is(false));
     }
 
@@ -56,6 +58,7 @@ public class CardIdResourceITest {
                 .body("brand", is("visa"))
                 .body("label", is("VISA CREDIT"))
                 .body("type", is("C"))
+                .body("prepaid", is("NOT_PREPAID"))
                 .body("corporate", is(false));
     }
 
@@ -67,6 +70,7 @@ public class CardIdResourceITest {
                 .body("brand", is("american-express"))
                 .body("label", is("AMERICAN EXPRESS"))
                 .body("type", is("C"))
+                .body("prepaid", is("UNKNOWN"))
                 .body("corporate", is(false));
     }
 
@@ -78,7 +82,20 @@ public class CardIdResourceITest {
                 .body("brand", is("master-card"))
                 .body("label", is("MCI CREDIT"))
                 .body("type", is("C"))
+                .body("prepaid", is("UNKNOWN"))
                 .body("corporate", is(true));
+    }
+
+    @Test
+    public void shouldFindPrepaidCard() {
+        getCardInformation("4860880000000001")
+                .statusCode(200)
+                .contentType(JSON)
+                .body("brand", is("visa"))
+                .body("label", is("VISA DEBIT"))
+                .body("type", is("D"))
+                .body("prepaid", is("PREPAID"))
+                .body("corporate", is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/card/model/CardInformationTest.java
+++ b/src/test/java/uk/gov/pay/card/model/CardInformationTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.*;
 public class CardInformationTest {
 
     @Test
-    public void shouldAdjustRangesLegnth() {
+    public void shouldAdjustRangesLength() {
 
         CardInformation cardInformation = new CardInformation("visa", "D", "visa", 123456L, 123457L);
         cardInformation.updateRangeLength(11);


### PR DESCRIPTION
- Add `prepaid` to the response. Possible values are `PREPAID`, `NOT_PREPAID`
and `UNKNOWN`.
- Parse the prepaid value from the Worldpay data source and set appropriately
in the response. No implementation for other data sources which will default
the prepaid status to `UNKNOWN`
- Updated and created tests.