### PR TITLE
BAU: Specify UTF-8 as the encoding of Java source files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <artifactId>pay-cardid</artifactId>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.5</dropwizard.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jmh.version>1.17.5</jmh.version>


### PR DESCRIPTION
This removes the following warning from the build:

`[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!`