### PR TITLE
BAU: Rearrange Dockerfile to reduce the number of rebuilt layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ EXPOSE 8081
 
 WORKDIR /app
 
+ADD docker-startup.sh /app/docker-startup.sh
+COPY data/sources/ /app/data/
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
-COPY data/sources/ /app/data/
-RUN ls -a /app/data/*
-ADD docker-startup.sh /app/docker-startup.sh
 
 CMD bash ./docker-startup.sh


### PR DESCRIPTION
The thing which changes most often is the .jar, so add that to the docker image
last. This means that in the common case, we only rebuild one layer rather than
several.

