### PR TITLE
PP-4528: Upgrade maven-jar-plugin from 2.4 to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifest>


### PR DESCRIPTION
Bring this plugin up to date

Release notes (thanks @alexbishop1 for the digging):
2.4 was released Feb 2012: http://maven.40175.n5.nabble.com/Maven-Jar-Plugin-2-4-Released-td5449745.html

2.5* — http://mail-archives.apache.org/mod_mbox/maven-announce/201406.mbox/%3C20140624102030.A2EEB11E99@minotaur.apache.org%3E
2.6 — http://mail-archives.apache.org/mod_mbox/maven-users/201503.mbox/%3C20150310103739.55BAD174B2@minotaur.apache.org%3E
3.0.0 — http://mail-archives.apache.org/mod_mbox/maven-announce/201605.mbox/%3C20160515194703.8B01819730@minotaur.apache.org%3E
3.1.0 — https://blogs.apache.org/maven/entry/apache-maven-jar-plugin-version
3.1.1 — https://blogs.apache.org/maven/entry/apache-maven-jar-plugin-version1