### PR TITLE
PP-4574: Upgrade hamcrest to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.5</dropwizard.version>
-        <hamcrest.version>1.3</hamcrest.version>
+        <hamcrest.version>2.1</hamcrest.version>
         <jmh.version>1.17.5</jmh.version>
         <jackson.version>2.9.7</jackson.version>
         <dependency-check.skip>true</dependency-check.skip>
@@ -43,6 +43,18 @@
 
         <!-- testing -->
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>
@@ -58,18 +70,6 @@
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>2.9.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/card/db/loader/WorldpayPrepaidParserTest.java
+++ b/src/test/java/uk/gov/pay/card/db/loader/WorldpayPrepaidParserTest.java
@@ -3,11 +3,9 @@ package uk.gov.pay.card.db.loader;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import uk.gov.pay.card.db.loader.WorldpayPrepaidParser;
 import uk.gov.pay.card.model.PrepaidStatus;
 
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 
 public class WorldpayPrepaidParserTest {
 
@@ -16,36 +14,36 @@ public class WorldpayPrepaidParserTest {
 
     @Test
     public void shouldReturnPrepaidForY() {
-        assertThat(WorldpayPrepaidParser.parse("Y"), equalTo(PrepaidStatus.PREPAID));
+        assertEquals(WorldpayPrepaidParser.parse("Y"), PrepaidStatus.PREPAID);
     }
 
     @Test
     public void shouldReturnPrepaidForN() {
-        assertThat(WorldpayPrepaidParser.parse("N"), equalTo(PrepaidStatus.NOT_PREPAID));
+        assertEquals(WorldpayPrepaidParser.parse("N"), PrepaidStatus.NOT_PREPAID);
     }
 
     @Test
     public void shouldReturnUnknownForU() {
-        assertThat(WorldpayPrepaidParser.parse("U"), equalTo(PrepaidStatus.UNKNOWN));
+        assertEquals(WorldpayPrepaidParser.parse("U"), PrepaidStatus.UNKNOWN);
     }
 
     @Test
     public void shouldReturnUnknownForNull() {
-        assertThat(WorldpayPrepaidParser.parse(null), equalTo(PrepaidStatus.UNKNOWN));
+        assertEquals(WorldpayPrepaidParser.parse(null), PrepaidStatus.UNKNOWN);
     }
 
     @Test
     public void shouldReturnUnknownForEmptyString() {
-        assertThat(WorldpayPrepaidParser.parse(""), equalTo(PrepaidStatus.UNKNOWN));
+        assertEquals(WorldpayPrepaidParser.parse(""), PrepaidStatus.UNKNOWN);
     }
 
     @Test
     public void shouldReturnUnknownForYES() {
-        assertThat(WorldpayPrepaidParser.parse("YES"), equalTo(PrepaidStatus.UNKNOWN));
+        assertEquals(WorldpayPrepaidParser.parse("YES"), PrepaidStatus.UNKNOWN);
     }
 
     @Test
     public void shouldReturnUnknownForNO() {
-        assertThat(WorldpayPrepaidParser.parse("NO"), equalTo(PrepaidStatus.UNKNOWN));
+        assertEquals(WorldpayPrepaidParser.parse("NO"), PrepaidStatus.UNKNOWN);
     }
 }

--- a/src/test/java/uk/gov/pay/card/filters/LoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/card/filters/LoggingFilterTest.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -87,7 +87,7 @@ public class LoggingFilterTest {
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl)));
+        assertEquals(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl), loggingEvents.get(0).getFormattedMessage());
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
         assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
         String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");
@@ -109,7 +109,7 @@ public class LoggingFilterTest {
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", "", requestMethod, requestUrl)));
+        assertEquals(format("[%s] - %s to %s began", "", requestMethod, requestUrl), loggingEvents.get(0).getFormattedMessage());
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
         assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", "", requestMethod, requestUrl)));
         verify(mockFilterChain).doFilter(mockRequest, mockResponse);
@@ -133,10 +133,10 @@ public class LoggingFilterTest {
         verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl)));
-        assertThat(loggingEvents.get(1).getFormattedMessage(), is("Exception - cardid request - " + requestUrl + " - exception - " + exception.getMessage()));
-        assertThat(loggingEvents.get(1).getLevel(), is(Level.ERROR));
-        assertThat(loggingEvents.get(1).getThrowableProxy().getMessage(), is("Failed request"));
+        assertEquals(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl), loggingEvents.get(0).getFormattedMessage());
+        assertEquals(format("Exception - cardid request - %s - exception - %s", requestUrl, exception.getMessage()), loggingEvents.get(1).getFormattedMessage());
+        assertEquals(Level.ERROR, loggingEvents.get(1).getLevel());
+        assertEquals("Failed request", loggingEvents.get(1).getThrowableProxy().getMessage());
         String endLogMessage = loggingEvents.get(2).getFormattedMessage();
         assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
         String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");

--- a/src/test/java/uk/gov/pay/card/model/CardTypeTest.java
+++ b/src/test/java/uk/gov/pay/card/model/CardTypeTest.java
@@ -4,8 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 
 public class CardTypeTest {
 
@@ -15,7 +14,7 @@ public class CardTypeTest {
     @Test
     public void shouldFindCardClass() {
         CardInformation cardInformation = new CardInformation("A", "C", "A", 1L, 2L);
-        assertThat(cardInformation.getCardType(), is(CardType.CREDIT));
+        assertEquals(CardType.CREDIT, cardInformation.getCardType());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/card/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/card/service/CardServiceTest.java
@@ -7,8 +7,8 @@ import uk.gov.pay.card.model.CardInformation;
 
 import java.util.Optional;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,15 +25,15 @@ public class CardServiceTest {
     }
 
     @Test
-    public void shouldStripTheCardNumberTo11DigitsForBingRangeLookup() {
+    public void shouldStripTheCardNumberTo11DigitsForBinRangeLookup() {
 
         CardInformation expectedCardInformation = new CardInformation("visa", "D", "visa", 11000L, 13000L);
         when(cardInformationStore.find("12345678901")).thenReturn(Optional.of(expectedCardInformation));
 
         Optional<CardInformation> cardInformation = cardService.getCardInformation("1234567890123456");
 
-        assertThat(cardInformation.isPresent(), is(true));
-        assertThat(expectedCardInformation, is(cardInformation.get()));
+        assertTrue(cardInformation.isPresent());
+        assertEquals(expectedCardInformation, cardInformation.get());
         verify(cardInformationStore).find("12345678901");
     }
 }


### PR DESCRIPTION
hamcrest-core is now just 'hamcrest'

hamcrest-library is now just a dummy transitional package to force upgrades for
projects which depend on it (e.g. junit 4.x)

Rewrite a bunch of our tests to not need hamcrest at all