### PR TITLE
BAU: Miscellaneous fixups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.5</dropwizard.version>
         <hamcrest.version>2.1</hamcrest.version>
-        <jmh.version>1.17.5</jmh.version>
+        <jmh.version>1.21</jmh.version>
         <jackson.version>2.9.7</jackson.version>
         <dependency-check.skip>true</dependency-check.skip>
     </properties>

--- a/src/main/java/uk/gov/pay/card/db/loader/WorldpayPrepaidParser.java
+++ b/src/main/java/uk/gov/pay/card/db/loader/WorldpayPrepaidParser.java
@@ -2,7 +2,7 @@ package uk.gov.pay.card.db.loader;
 
 import uk.gov.pay.card.model.PrepaidStatus;
 
-public class WorldpayPrepaidParser {
+class WorldpayPrepaidParser {
 
     public static PrepaidStatus parse(String value) {
         if ("Y".equals(value)) {

--- a/src/test/java/uk/gov/pay/card/filters/LoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/card/filters/LoggingFilterTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static java.lang.String.format;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -88,7 +88,7 @@ public class LoggingFilterTest {
 
         assertEquals(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl), loggingEvents.get(0).getFormattedMessage());
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
+        assertThat(endLogMessage, startsWith(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
         String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");
         assertTrue(NumberUtils.isCreatable(timeTaken[0]));
         verify(mockFilterChain).doFilter(mockRequest, mockResponse);
@@ -110,7 +110,7 @@ public class LoggingFilterTest {
 
         assertEquals(format("[%s] - %s to %s began", "", requestMethod, requestUrl), loggingEvents.get(0).getFormattedMessage());
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", "", requestMethod, requestUrl)));
+        assertThat(endLogMessage, startsWith(format("[%s] - %s to %s ended - total time ", "", requestMethod, requestUrl)));
         verify(mockFilterChain).doFilter(mockRequest, mockResponse);
     }
 
@@ -137,7 +137,7 @@ public class LoggingFilterTest {
         assertEquals(Level.ERROR, loggingEvents.get(1).getLevel());
         assertEquals("Failed request", loggingEvents.get(1).getThrowableProxy().getMessage());
         String endLogMessage = loggingEvents.get(2).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
+        assertThat(endLogMessage, startsWith(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
         String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");
         assertTrue(NumberUtils.isCreatable(timeTaken[0]));
     }

--- a/src/test/java/uk/gov/pay/card/filters/LoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/card/filters/LoggingFilterTest.java
@@ -20,7 +20,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;


### PR DESCRIPTION
## WHAT
* Upgrade JMH benchmarking library to 1.21 (no changes needed)
* Use `startsWith` instead of `containsString` for prefix matching in `LoggingFilterTest`
* Address a couple of warnings from IntelliJ - make `WorldpayPrepaidParser` package private and remove an unused import from `LoggingFilterTest`

I think CI is enough to test this

