### PR TITLE
Pp 4576 simplify brand transformation

### DIFF
--- a/src/main/java/uk/gov/pay/card/db/RangeSetCardInformationStore.java
+++ b/src/main/java/uk/gov/pay/card/db/RangeSetCardInformationStore.java
@@ -34,7 +34,6 @@ public class RangeSetCardInformationStore implements CardInformationStore {
     @Override
     public void put(CardInformation cardInformation) {
         cardInformation.updateRangeLength(CARD_RANGE_LENGTH);
-        cardInformation.transformBrand();
         Range<Long> range = Range.closed(cardInformation.getMin(), cardInformation.getMax());
         rangeSet.add(range);
         store.put(range, cardInformation);

--- a/src/main/java/uk/gov/pay/card/model/CardInformation.java
+++ b/src/main/java/uk/gov/pay/card/model/CardInformation.java
@@ -34,13 +34,16 @@ public class CardInformation {
     }
 
     public CardInformation(String brand, String type, String label, Long min, Long max, boolean corporate, PrepaidStatus prepaidStatus) {
-        this.brand = brand;
         this.cardType = CardType.of(type);
         this.label = label;
         this.min = min;
         this.max = max;
         this.corporate = corporate;
         this.prepaidStatus = prepaidStatus;
+
+        if (brand != null) {
+            this.brand = brandMapping.getOrDefault(brand, brand.toLowerCase());
+        }
     }
 
     public CardInformation(String brand, String type, String label, Long min, Long max) {
@@ -78,12 +81,6 @@ public class CardInformation {
     public void updateRangeLength(int numLength) {
         min = Long.valueOf(format("%-" + numLength + "d", min).replace(" ", "0"));
         max = Long.valueOf(format("%-" + numLength + "d", max).replace(" ", "9"));
-    }
-
-    public void transformBrand() {
-        if (this.brand != null) {
-            this.brand = brandMapping.getOrDefault(brand, brand.toLowerCase());
-        }
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/card/model/CardInformation.java
+++ b/src/main/java/uk/gov/pay/card/model/CardInformation.java
@@ -81,10 +81,9 @@ public class CardInformation {
     }
 
     public void transformBrand() {
-        if (brandMapping.containsKey(brand)) {
-            this.brand = brandMapping.get(brand);
+        if (this.brand != null) {
+            this.brand = brandMapping.getOrDefault(brand, brand.toLowerCase());
         }
-        this.brand = this.getBrand().toLowerCase();
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
+++ b/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
@@ -134,21 +134,6 @@ public class RangeSetCardInformationStoreTest {
     }
 
     @Test
-    public void shouldTransformMastercardBrand() throws Exception {
-        URL url = this.getClass().getResource("/worldpay/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
-
-        cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
-        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
-
-        Optional<CardInformation> cardInformation = cardInformationStore.find("51122666111");
-
-        assertTrue(cardInformation.isPresent());
-        assertThat(cardInformation.get().getBrand(), is("master-card"));
-
-    }
-
-    @Test
     public void shouldFindCorporateCreditCardType() throws Exception {
         URL url = this.getClass().getResource("/worldpay/");
         BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());

--- a/src/test/java/uk/gov/pay/card/model/CardInformationTest.java
+++ b/src/test/java/uk/gov/pay/card/model/CardInformationTest.java
@@ -2,8 +2,7 @@ package uk.gov.pay.card.model;
 
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class CardInformationTest {
 
@@ -12,92 +11,80 @@ public class CardInformationTest {
 
         CardInformation cardInformation = new CardInformation("visa", "D", "visa", 123456L, 123457L);
         cardInformation.updateRangeLength(11);
-        assertThat(cardInformation.getMin(), is(12345600000L));
-        assertThat(cardInformation.getMax(), is(12345799999L));
+        assertEquals(12345600000L, cardInformation.getMin().longValue());
+        assertEquals(12345799999L, cardInformation.getMax().longValue());
 
     }
 
     @Test
     public void shouldTransformJcbBrand() {
         CardInformation cardInformation = new CardInformation("JCB", "C", "JCB", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("jcb"));
+        assertEquals("jcb", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformDiscoverBrand() {
         CardInformation cardInformation = new CardInformation("DISCOVER", "C", "DISCOVER", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("discover"));
+        assertEquals("discover", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformMaestroBrand() {
         CardInformation cardInformation = new CardInformation("MAESTRO", "D", "MAESTRO", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("maestro"));
+        assertEquals("maestro", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformUnionpayBrand() {
         CardInformation cardInformation = new CardInformation("UNIONPAY", "C", "UNIONPAY", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("unionpay"));
+        assertEquals("unionpay", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformAmexBrand() {
         CardInformation cardInformation = new CardInformation("AMERICAN EXPRESS", "C", "AMERICAN EXPRESS", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("american-express"));
+        assertEquals("american-express", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformDinersClubBrand() {
         CardInformation cardInformation = new CardInformation("DINERS CLUB", "C", "DINERS CLUB", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("diners-club"));
+        assertEquals("diners-club", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformMastercardBrand() {
         CardInformation cardInformation = new CardInformation("MC", "D", "MC", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("master-card"));
+        assertEquals("master-card", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformMCIDebitMastercardBrand() {
         CardInformation cardInformation = new CardInformation("MCI DEBIT", "D", "MCI DEBIT", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("master-card"));
+        assertEquals("master-card", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformMCICreditMastercardBrand() {
         CardInformation cardInformation = new CardInformation("MCI CREDIT", "C", "MCI CREDIT", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("master-card"));
+        assertEquals("master-card", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformVisaCreditBrand() {
         CardInformation cardInformation = new CardInformation("VISA CREDIT", "C", "VISA CREDIT", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("visa"));
+        assertEquals("visa", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformVisaDebitBrand() {
         CardInformation cardInformation = new CardInformation("VISA DEBIT", "D", "VISA DEBIT", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("visa"));
+        assertEquals("visa", cardInformation.getBrand());
     }
 
     @Test
     public void shouldTransformVisaElectronBrand() {
         CardInformation cardInformation = new CardInformation("ELECTRON", "D", "ELECTRON", 123456L, 123457L);
-        cardInformation.transformBrand();
-        assertThat(cardInformation.getBrand(), is("visa"));
+        assertEquals("visa", cardInformation.getBrand());
     }
 }


### PR DESCRIPTION
## WHAT
The cardid service presents a different representation of the card brand via its API than is present in the BIN range data provided by the PSPs.

To do this it contains an internal mapping of the brand as it appears in the BIN data (e.g. "MCI CREDIT") and the brand as it is presented via the API (e.g. "master-card").

The way this mapping is applied is rather cumbersome. Firstly, a CardInformation object is created using the values from the BIN range data. Later, when these objects are added to the card information store, a method is called to apply the translation to the branding text, mutating the object.

It would be cleaner to apply this mapping at object construction time so that the text as it appears in the BIN range file is translated on load. This would remove the need for the CardInformationStore to remember to call the 'transformBrand' method in order to make sure the mapping takes place.

## HOW 
Acceptance criteria

* Tests still pass
* CardInformation no longer has a 'transformBrand()' method
* Consumers of CardInformation no longer know this mapping takes place


