### PR TITLE
PP-4584: Manage HTTP proxies via env. vars

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
+set -eu
+
 JAVA_OPTS=${JAVA_OPTS:--Xms1500m -Xmx1500m}
+[ -z "${http_proxy:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttp.proxyHost=${http_proxy}"
+[ -z "${https_proxy:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttps.proxyHost=${https_proxy}"
+[ -z "${java_http_non_proxy_hosts:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttp.nonProxyHosts=${java_http_non_proxy_hosts}"
+
 java $JAVA_OPTS -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
Use environment variables to set JVM system properties for proxy configuration.

This makes the application respond to the following 3 environment variables:

http_proxy - passed as http.proxyHost
https_proxy - passed as https.proxyHost
java_http_non_proxy_hosts - passed as http.nonProxyHosts