### PR TITLE
PP-4946 Add `jaxb-api` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
             <version>2.4.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## WHAT YOU DID

Added `JAXB API` as dependency as it is removed from Java11 JDK

with @danworth

## How to test

- CI should pass