### PR TITLE
PP-4864: Remove reference to CERTS_PATH environment variable

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -7,8 +7,6 @@ then
   set +a  
 fi
 
-export CERTS_PATH=$WORKSPACE/pay-scripts/services/ssl/certs
-
 export TEST_CARD_DATA_LOCATION=./data/sources/test-cards
 export WORLDPAY_DATA_LOCATION=./data/sources/worldpay
 export DISCOVER_DATA_LOCATION=./data/sources/discover


### PR DESCRIPTION
cardid does not make use of this environment variable. Remove it.