### PR TITLE
PP-5057 Add some extra logging to track down 500 errors

### DIFF
--- a/src/main/java/uk/gov/pay/card/db/RangeSetCardInformationStore.java
+++ b/src/main/java/uk/gov/pay/card/db/RangeSetCardInformationStore.java
@@ -4,8 +4,11 @@ package uk.gov.pay.card.db;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.card.db.loader.BinRangeDataLoader;
 import uk.gov.pay.card.model.CardInformation;
+import uk.gov.pay.card.service.CardService;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +16,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 
 public class RangeSetCardInformationStore implements CardInformationStore {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CardService.class);
 
     private final List<BinRangeDataLoader> binRangeLoaders;
     private final RangeSet<Long> rangeSet;
@@ -41,6 +46,11 @@ public class RangeSetCardInformationStore implements CardInformationStore {
 
     @Override
     public Optional<CardInformation> find(String prefix) {
+        try {
+            Long.valueOf(prefix);
+        } catch (NumberFormatException e) {
+            LOGGER.error("Received card number that cannot be parsed into long");
+        }
         Range<Long> longRange = rangeSet.rangeContaining(Long.valueOf(prefix));
         if(longRange != null) {
             return Optional.ofNullable(store.get(longRange));

--- a/src/main/java/uk/gov/pay/card/service/CardService.java
+++ b/src/main/java/uk/gov/pay/card/service/CardService.java
@@ -1,11 +1,16 @@
 package uk.gov.pay.card.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.card.db.CardInformationStore;
+import uk.gov.pay.card.db.loader.BinRangeDataLoader;
 import uk.gov.pay.card.model.CardInformation;
 
 import java.util.Optional;
 
 public class CardService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CardService.class);
 
     private final CardInformationStore cardInformationStore;
 
@@ -14,6 +19,9 @@ public class CardService {
     }
 
     public Optional<CardInformation> getCardInformation(String cardNumber) {
+        if (cardNumber.length() < CardInformationStore.CARD_RANGE_LENGTH) {
+            LOGGER.error("Received card number with fewer than {} characters", CardInformationStore.CARD_RANGE_LENGTH);
+        }
         return cardInformationStore.find(cardNumber.substring(0, CardInformationStore.CARD_RANGE_LENGTH));
     }
 }


### PR DESCRIPTION
Add some extra logging in areas of the card information lookup code that look like they would be problematic if assumed preconditions are not met, in the hope this will shed some light on the occasional 500 errors.