### PR TITLE
Add surefire and failsafe maven plugins for running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
           long stepBuildTime = System.currentTimeMillis()
 
           sh 'mvn -version'
-          sh 'mvn clean package'
+          sh 'mvn clean verify'
           postSuccessfulMetrics("cardid.maven-build", stepBuildTime)
         }
       }

--- a/build-local.sh
+++ b/build-local.sh
@@ -4,5 +4,5 @@ set -e
 
 cd "$(dirname "$0")"
 
-mvn -DskipTests clean package
+mvn -DskipITs clean verify
 docker build -t govukpay/cardid:local .

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,26 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>failsafe-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.6.0</version>

--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceIT.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceIT.java
@@ -13,7 +13,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.core.Is.is;
 
-public class CardIdResourceITest {
+public class CardIdResourceIT {
 
     @Rule
     public final DropwizardAppRule<CardConfiguration> app = new DropwizardAppRule<>(

--- a/src/test/resources/config/config.yaml
+++ b/src/test/resources/config/config.yaml
@@ -1,0 +1,23 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: ${PORT:-8080}
+  adminConnectors:
+    - type: http
+      port: ${ADMIN_PORT:-8081}
+
+logging:
+  level: INFO
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+
+worldpayDataLocation: ${WORLDPAY_DATA_LOCATION:-/app/data/worldpay}
+discoverDataLocation: ${DISCOVER_DATA_LOCATION:-/app/data/discover}
+testCardDataLocation: ${TEST_CARD_DATA_LOCATION:-/app/data/test-cards}
+
+graphiteHost: ${METRICS_HOST:-localhost}
+graphitePort: ${METRICS_PORT:-8092}


### PR DESCRIPTION
Introduce the surefire and maven plugins for running our tests and rename the
single integration test to match their default naming scheme.

Include unit tests in local builds and change the CI build to run `mvn verify`
in order to exercise the integration tests.

Interestingly, this caused integration tests to fail because they couldn't find
a Dropwizard configuration. Copying config.yaml from src/main/resources/config
to src/test/resources/config sorted that out but I don't know if it's the
correct thing to do.