### PR TITLE
RED-45 RED-46: Stop using govukpay/openjdk base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-FROM govukpay/openjdk:adoptopenjdk-jre-11.0.3_7-alpine
+# adoptopenjdk/openjdk11:jre-11.0.3_7-alpine
+FROM adoptopenjdk/openjdk11@sha256:eaa182283f19d3f0ee0c6217d29e299bb4056d379244ce957e30dcdc9e278e1e
 
-RUN apk --no-cache upgrade
+RUN ["apk", "--no-cache", "upgrade"]
 
-RUN apk --no-cache add bash
+ARG DNS_TTL=15
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.security"
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081


### PR DESCRIPTION
Our base image doesn't do anything very special.

Use the adoptopenjdk image directly and import the base image logic

So that we can have confidence our base images aren't being changed without our
knowledge, reference them by digest instead of tag (as tags are not immutable).

Also, add a comment detailing the tag the digest corresponds to.