### PR TITLE
RED-46: Remove bash usage from the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,15 @@ RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.sec
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081
+ENV JAVA_OPTS -Xms1500m -Xmx1500m
 
 EXPOSE 8080
 EXPOSE 8081
 
 WORKDIR /app
 
-COPY docker-startup.sh /app/docker-startup.sh
 COPY data/sources/ /app/data/
 COPY target/*.yaml /app/
 COPY target/pay-*-allinone.jar /app/
 
-CMD bash ./docker-startup.sh
+CMD java $JAVA_OPTS -jar ./pay-*-allinone.jar server ./*.yaml

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-JAVA_OPTS=${JAVA_OPTS:--Xms1500m -Xmx1500m}
-java $JAVA_OPTS -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
We try to run our scripts with bash, but bash isn't installed in the container.

We don't actually need bash, so stop asking for it.

Move the default for JAVA_OPTS to the Dockerfile using `ENV` rather than shell

Run java directly from the Dockerfile without a shell script wrapper. This will
have the side benefit of allowing signals to be delivered directly to the
running Java process, so e.g. Ctrl-c will now kill the application.