### PR TITLE
Make java PID 1 in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY data/sources/ /app/data/
 COPY target/*.yaml /app/
 COPY target/pay-*-allinone.jar /app/
 
-CMD java $JAVA_OPTS -jar ./pay-*-allinone.jar server ./*.yaml
+CMD exec java $JAVA_OPTS -jar ./pay-*-allinone.jar server ./*.yaml


### PR DESCRIPTION
Without using the array syntax for `CMD` in the `Dockerfile` we end up
executing `java` with a shell process.

This is unnecessary and undesirable. The shell will absorb the SIGTERM sent to
shut the container down, hiding it from java and leading to an ungraceful
shutdown by the container orchestrator.

Use 'exec' to avoid forking a new process on startup. This will ensure `java`
is process ID 1 within the container and receives signals directly.