### PR TITLE
Use tini to manage running Java within Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM adoptopenjdk/openjdk11@sha256:eaa182283f19d3f0ee0c6217d29e299bb4056d379244ce957e30dcdc9e278e1e
 
 RUN ["apk", "--no-cache", "upgrade"]
+RUN ["apk", "--no-cache", "add", "tini"]
 
 ARG DNS_TTL=15
 
@@ -22,5 +23,7 @@ WORKDIR /app
 COPY data/sources/ /app/data/
 COPY target/*.yaml /app/
 COPY target/pay-*-allinone.jar /app/
+
+ENTRYPOINT ["tini", "-e", "143", "--"]
 
 CMD exec java $JAVA_OPTS -jar ./pay-*-allinone.jar server ./*.yaml


### PR DESCRIPTION
Now that Java is running as PID 1, we have solved one problem but created another.

Signals sent to the container will now reach Java correctly instead of being swallowed by bash, but two problems have been created:

* If Java creates any child processes and those processes (or any of their
  children) die, Java will be the parent of them and will not know to waitpid()
  on them, so they will remain zombies forever. This is not a problem for
  cardid as no such child processes should be created, but it's still not really
  correct.
* When SIGTERM is sent to the container in order to shut the service down, Java
  will exit with an exit status of 143, even though it shut down cleanly. tini
  can map this exit status to 0 in order to properly commmunicate the successful
  exit to the container orchestrator.

tini solves both of these problems - it will correctly reparent orphaned child
processes and can remap the strange exit code of Java to something more
palatable.