### PR TITLE
Remove Dockerfile comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# adoptopenjdk/openjdk11:jre-11.0.3_7-alpine
 FROM adoptopenjdk/openjdk11@sha256:eaa182283f19d3f0ee0c6217d29e299bb4056d379244ce957e30dcdc9e278e1e
 
 RUN ["apk", "--no-cache", "upgrade"]


### PR DESCRIPTION
Now that dependabot can bump the FROM lines of our Dockerfiles, these comments
will become stale and misleading.