### PR TITLE
Pull BIN range data from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The service provides an API that could be accessed to retrieve card information 
 ## Environment Variables
 
   - `ADMIN_PORT`: The port number to listen for Dropwizard admin requests on. Defaults to `8081`.
-  - `DISCOVER_DATA_LOCATION`: Where to load bin ranges for Discover cards from. Defaults to `/app/data/discover`.
+  - `DISCOVER_DATA_LOCATION`: The URL to load bin ranges for Discover cards from. Defaults to `file:///app/data/discover/Merchant_Marketing.csv`.
   - `JAVA_OPTS`: Options to pass to the JRE. Defaults to `-Xms1500m -Xmx1500m`.
   - `METRICS_HOST`: The hostname to send graphite metrics to. Defaults to `localhost`.
   - `METRICS_PORT`: The port on `METRICS_HOST` to send graphite metrics to. Defaults to `8081`.
   - `PORT`: The port number to listen for requests on. Defaults to `8080`.
-  - `TEST_CARD_DATA_LOCATION`: Where to load bin ranges for test cards from. Defaults to `/app/data/test-cards`.
-  - `WORLDPAY_DATA_LOCATION`: Where to load the Worldpay bin range data from. Defaults to `/app/data/worldpay`.
+  - `TEST_CARD_DATA_LOCATION`: The URL to load bin ranges for test cards from. Defaults to `file:///app/data/test-cards/test-card-bin-ranges.csv`.
+  - `WORLDPAY_DATA_LOCATION`: The URL to load the Worldpay bin range data from. Defaults to `file:///app/data/worldpay/GENERIC2ISOCPTISSUERPREPAID.CSV`.
 
 ## Card data
 The data for this service would need to be sourced externally from relevant providers. 

--- a/env.sh
+++ b/env.sh
@@ -7,8 +7,4 @@ then
   set +a  
 fi
 
-export TEST_CARD_DATA_LOCATION=./data/sources/test-cards
-export WORLDPAY_DATA_LOCATION=./data/sources/worldpay
-export DISCOVER_DATA_LOCATION=./data/sources/discover
-
 eval "$@"

--- a/src/main/java/uk/gov/pay/card/app/config/CardConfiguration.java
+++ b/src/main/java/uk/gov/pay/card/app/config/CardConfiguration.java
@@ -3,17 +3,18 @@ package uk.gov.pay.card.app.config;
 import io.dropwizard.Configuration;
 
 import javax.validation.constraints.NotNull;
+import java.net.URL;
 
 public class CardConfiguration extends Configuration {
 
     @NotNull
-    private String worldpayDataLocation;
+    private URL worldpayDataLocation;
 
     @NotNull
-    private String discoverDataLocation;
+    private URL discoverDataLocation;
 
     @NotNull
-    private String testCardDataLocation;
+    private URL testCardDataLocation;
 
     @NotNull
     private String graphiteHost;
@@ -21,15 +22,15 @@ public class CardConfiguration extends Configuration {
     @NotNull
     private String graphitePort;
 
-    public String getDiscoverDataLocation() {
+    public URL getDiscoverDataLocation() {
         return discoverDataLocation;
     }
 
-    public String getWorldpayDataLocation() {
+    public URL getWorldpayDataLocation() {
         return worldpayDataLocation;
     }
 
-    public String getTestCardDataLocation() {
+    public URL getTestCardDataLocation() {
         return testCardDataLocation;
     }
 

--- a/src/main/java/uk/gov/pay/card/db/loader/BinRangeDataLoader.java
+++ b/src/main/java/uk/gov/pay/card/db/loader/BinRangeDataLoader.java
@@ -90,7 +90,7 @@ public class BinRangeDataLoader {
             logger.info("{} records loaded... DONE", count);
 
         } catch (Exception e) {
-            throw new DataLoaderException("Exception loading file at:" + filePath, e);
+            throw new DataLoaderException(format("Exception loading file at: %s", filePath), e);
         }
 
         logger.info("Finished initialising the card information store - {}", cardInformationStore);

--- a/src/main/java/uk/gov/pay/card/db/loader/BinRangeDataLoader.java
+++ b/src/main/java/uk/gov/pay/card/db/loader/BinRangeDataLoader.java
@@ -6,10 +6,6 @@ import uk.gov.pay.card.db.CardInformationStore;
 import uk.gov.pay.card.model.CardInformation;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicLong;
@@ -22,7 +18,7 @@ public class BinRangeDataLoader {
 
     private static final Logger logger = LoggerFactory.getLogger(BinRangeDataLoader.class);
     private final String name;
-    private final String source;
+    private final URL source;
     private final String delimeter;
     private final String dataRowIdentifier;
     private final Function<String[], CardInformation> cardInformationExtractor;
@@ -47,20 +43,20 @@ public class BinRangeDataLoader {
 
     public static class BinRangeDataLoaderFactory {
 
-        public static BinRangeDataLoader worldpay(String filePath) {
-            return new BinRangeDataLoader("Worldpay", filePath, WORLDPAY_DELIMITER, WORLDPAY_ROW_IDENTIFIER, WORLDPAY_CARD_INFORMATION_EXTRACTOR);
+        public static BinRangeDataLoader worldpay(URL source) {
+            return new BinRangeDataLoader("Worldpay", source, WORLDPAY_DELIMITER, WORLDPAY_ROW_IDENTIFIER, WORLDPAY_CARD_INFORMATION_EXTRACTOR);
         }
 
-        public static BinRangeDataLoader discover(String filePath) {
-            return new BinRangeDataLoader("Discover", filePath, DISCOVER_DELIMITER, DISCOVER_ROW_IDENTIFIER, DISCOVER_CARD_INFORMATION_EXTRACTOR);
+        public static BinRangeDataLoader discover(URL source) {
+            return new BinRangeDataLoader("Discover", source, DISCOVER_DELIMITER, DISCOVER_ROW_IDENTIFIER, DISCOVER_CARD_INFORMATION_EXTRACTOR);
         }
 
-        public static BinRangeDataLoader testCards(String filePath) {
-            return new BinRangeDataLoader("Test Cards", filePath, TEST_CARD_DATA_DELIMITER, TEST_CARD_DATA_ROW_IDENTIFIER, TEST_CARD_DATA_INFORMATION_EXTRACTOR);
+        public static BinRangeDataLoader testCards(URL source) {
+            return new BinRangeDataLoader("Test Cards", source, TEST_CARD_DATA_DELIMITER, TEST_CARD_DATA_ROW_IDENTIFIER, TEST_CARD_DATA_INFORMATION_EXTRACTOR);
         }
     }
 
-    private BinRangeDataLoader(String name, String source, String delimeter, String dataRowIdentifier, Function<String[], CardInformation> cardInformationExtractor) {
+    private BinRangeDataLoader(String name, URL source, String delimeter, String dataRowIdentifier, Function<String[], CardInformation> cardInformationExtractor) {
         this.name = name;
         this.source = source;
         this.delimeter = delimeter;
@@ -73,7 +69,7 @@ public class BinRangeDataLoader {
         final AtomicLong lastPrintedCount = new AtomicLong(System.currentTimeMillis());
         final AtomicLong count = new AtomicLong(0);
 
-        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(getBinRangeData()))) {
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(source.openStream()))) {
             bufferedReader
                     .lines()
                     .forEach(line -> {
@@ -91,58 +87,16 @@ public class BinRangeDataLoader {
                     });
 
             logger.info("{} records loaded... DONE", count);
-
         } catch (Exception e) {
-            throw new DataLoaderException(format("Exception loading file at: %s", source), e);
+            throw new DataLoaderException(format("Exception loading file at: %s", source.toString()), e);
         }
 
         logger.info("Finished initialising the card information store - {}", cardInformationStore);
-
     }
 
-    private InputStream getBinRangeData() throws DataLoaderException, IOException {
-        return source.charAt(0) == '/' || source.indexOf(':') == -1
-                ? new FileInputStream(getBinRangeFile())
-                : new URL(source).openStream();
-    }
-
-    private File getBinRangeFile() throws DataLoaderException {
-        File folder = new File(source);
-        File[] matchingFiles = folder.listFiles((dir, fileName) -> fileName.toLowerCase().endsWith("csv"));
-
-        return validateDirectorysAndGetFile(matchingFiles);
-    }
-
-    private File validateDirectorysAndGetFile(File[] matchingFiles) throws DataLoaderException {
-        if (matchingFiles != null) {
-            if (matchingFiles.length != 1) {
-                String message = null;
-
-                if (matchingFiles.length == 0) message = "No CSV found at " + source;
-                if (matchingFiles.length > 1) message = "More than one CSV found at " + source;
-
-                logger.error(message);
-                throw new DataLoaderException(message);
-            } else {
-                logger.info("Found one file to load [{}]", source);
-                return matchingFiles[0];
-            }
-        } else {
-            final String message = format("No directory exists at [%s]", source);
-            logger.error(message);
-            throw new DataLoaderException(message);
-        }
-    }
-
-    class DataLoaderException extends Exception {
-
+    static class DataLoaderException extends Exception {
         DataLoaderException(String message, Throwable throwable) {
             super(message, throwable);
         }
-
-        DataLoaderException(String message) {
-            super(message);
-        }
     }
-
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -15,9 +15,9 @@ logging:
       target: stdout
       logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
 
-worldpayDataLocation: ${WORLDPAY_DATA_LOCATION:-/app/data/worldpay}
-discoverDataLocation: ${DISCOVER_DATA_LOCATION:-/app/data/discover}
-testCardDataLocation: ${TEST_CARD_DATA_LOCATION:-/app/data/test-cards}
+worldpayDataLocation: ${WORLDPAY_DATA_LOCATION:-file:///app/data/worldpay/GENERIC2ISOCPTISSUERPREPAID.CSV}
+discoverDataLocation: ${DISCOVER_DATA_LOCATION:-file:///app/data/discover/Merchant_Marketing.csv}
+testCardDataLocation: ${TEST_CARD_DATA_LOCATION:-file:///app/data/test-cards/test-card-bin-ranges.csv}
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}

--- a/src/test/java/uk/gov/pay/card/bench/RangeSetCardInformationStoreBenchmark.java
+++ b/src/test/java/uk/gov/pay/card/bench/RangeSetCardInformationStoreBenchmark.java
@@ -40,7 +40,7 @@ public class RangeSetCardInformationStoreBenchmark {
     @Setup(Level.Trial)
     public void setup() throws Exception {
         URL url = this.getClass().getResource("/worldpay/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
         cardInformationStore = new RangeSetCardInformationStore(singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
     }

--- a/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
+++ b/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
@@ -43,8 +43,8 @@ public class RangeSetCardInformationStoreTest {
     @Test
     public void shouldFindCardInformationForCardIdPrefix() throws Exception {
 
-        URL url = this.getClass().getResource("/worldpay/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        URL url = this.getClass().getResource("/worldpay/worldpay-bin-ranges.csv");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -59,8 +59,8 @@ public class RangeSetCardInformationStoreTest {
     @Test
     public void shouldFindCardInformationForCardIdPrefixWith11Digits() throws Exception {
 
-        URL url = this.getClass().getResource("/worldpay/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        URL url = this.getClass().getResource("/worldpay/worldpay-bin-ranges.csv");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -74,8 +74,8 @@ public class RangeSetCardInformationStoreTest {
 
     @Test
     public void shouldFindCardInformationWithRangeLengthLessThan9digits() throws Exception {
-        URL url = this.getClass().getResource("/worldpay-6-digits/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        URL url = this.getClass().getResource("/worldpay-6-digits/worldpay-bin-ranges-with-6digit-ranges.csv");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -89,8 +89,8 @@ public class RangeSetCardInformationStoreTest {
 
     @Test
     public void shouldFindCardInformationWithRange6digitsWhenRangeMinAndMaxAreTheSame() throws Exception {
-        URL url = this.getClass().getResource("/worldpay-6-digits/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        URL url = this.getClass().getResource("/worldpay-6-digits/worldpay-bin-ranges-with-6digit-ranges.csv");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -105,8 +105,8 @@ public class RangeSetCardInformationStoreTest {
     @Test
     public void shouldFindCardInformationWithRange9digitsWhenRangeMinAndMaxAreTheSame() throws Exception {
 
-        URL url = this.getClass().getResource("/worldpay-9-digits/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        URL url = this.getClass().getResource("/worldpay-9-digits/worldpay-bin-ranges-with-9digit-ranges.csv");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -135,8 +135,8 @@ public class RangeSetCardInformationStoreTest {
 
     @Test
     public void shouldFindCorporateCreditCardType() throws Exception {
-        URL url = this.getClass().getResource("/worldpay/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+        URL url = this.getClass().getResource("/worldpay/worldpay-bin-ranges.csv");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
 
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         worldpayBinRangeLoader.loadDataTo(cardInformationStore);

--- a/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
+++ b/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
@@ -44,7 +44,7 @@ public class RangeSetCardInformationStoreTest {
     public void shouldFindCardInformationForCardIdPrefix() throws Exception {
 
         URL url = this.getClass().getResource("/worldpay/worldpay-bin-ranges.csv");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -60,7 +60,7 @@ public class RangeSetCardInformationStoreTest {
     public void shouldFindCardInformationForCardIdPrefixWith11Digits() throws Exception {
 
         URL url = this.getClass().getResource("/worldpay/worldpay-bin-ranges.csv");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -75,7 +75,7 @@ public class RangeSetCardInformationStoreTest {
     @Test
     public void shouldFindCardInformationWithRangeLengthLessThan9digits() throws Exception {
         URL url = this.getClass().getResource("/worldpay-6-digits/worldpay-bin-ranges-with-6digit-ranges.csv");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -90,7 +90,7 @@ public class RangeSetCardInformationStoreTest {
     @Test
     public void shouldFindCardInformationWithRange6digitsWhenRangeMinAndMaxAreTheSame() throws Exception {
         URL url = this.getClass().getResource("/worldpay-6-digits/worldpay-bin-ranges-with-6digit-ranges.csv");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -106,7 +106,7 @@ public class RangeSetCardInformationStoreTest {
     public void shouldFindCardInformationWithRange9digitsWhenRangeMinAndMaxAreTheSame() throws Exception {
 
         URL url = this.getClass().getResource("/worldpay-9-digits/worldpay-bin-ranges-with-9digit-ranges.csv");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         cardInformationStore.initialiseCardInformation();
 
@@ -136,7 +136,7 @@ public class RangeSetCardInformationStoreTest {
     @Test
     public void shouldFindCorporateCreditCardType() throws Exception {
         URL url = this.getClass().getResource("/worldpay/worldpay-bin-ranges.csv");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
 
         cardInformationStore = new RangeSetCardInformationStore(Collections.singletonList(worldpayBinRangeLoader));
         worldpayBinRangeLoader.loadDataTo(cardInformationStore);

--- a/src/test/java/uk/gov/pay/card/db/loader/BinRangeDataLoaderTest.java
+++ b/src/test/java/uk/gov/pay/card/db/loader/BinRangeDataLoaderTest.java
@@ -35,6 +35,18 @@ public class BinRangeDataLoaderTest {
     }
 
     @Test
+    public void shouldLoadWorldpayBinRangesFromURL() throws Exception {
+
+        URL url = this.getClass().getResource("/worldpay/worldpay-bin-ranges.csv");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+
+        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
+        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
+
+        verify(cardInformationStore, times(5)).put(any(CardInformation.class));
+    }
+
+    @Test
     public void shouldLoadDiscoverBinRangesFromFile() throws Exception {
 
         URL url = this.getClass().getResource("/discover/");
@@ -47,10 +59,35 @@ public class BinRangeDataLoaderTest {
     }
 
     @Test
+    public void shouldLoadDiscoverBinRangesFromURL() throws Exception {
+
+        URL url = this.getClass().getResource("/discover/discover-bin-ranges.csv");
+        BinRangeDataLoader discoverBinRangeLoader = BinRangeDataLoaderFactory.discover(url.toString());
+
+        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
+        discoverBinRangeLoader.loadDataTo(cardInformationStore);
+
+        verify(cardInformationStore, times(3)).put(any(CardInformation.class));
+    }
+
+    @Test
     public void shouldThrowExceptionWhenNoFileIsFound() throws Exception {
 
         URL url = this.getClass().getResource("/empty/");
         BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+
+        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
+        exception.expect(BinRangeDataLoader.DataLoaderException.class);
+
+        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
+
+        verifyZeroInteractions(cardInformationStore);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenURLDoesNotExist() throws Exception {
+
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay("file:///nonexistent/path");
 
         CardInformationStore cardInformationStore = mock(CardInformationStore.class);
         exception.expect(BinRangeDataLoader.DataLoaderException.class);
@@ -75,9 +112,21 @@ public class BinRangeDataLoaderTest {
     }
 
     @Test
-    public void shouldLoadBinRangeDataAsCardInformation() throws Exception {
+    public void shouldLoadBinRangeDataAsCardInformationFromFile() throws Exception {
         URL url = this.getClass().getResource("/worldpay-single/");
         BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
+
+        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
+        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
+
+        CardInformation expectedCardInformation = new CardInformation("ELECTRON", "D", "ELECTRON", 511226111L, 511226200L, false, PrepaidStatus.PREPAID);
+        verify(cardInformationStore).put(expectedCardInformation);
+    }
+
+    @Test
+    public void shouldLoadBinRangeDataAsCardInformationFromURL() throws Exception {
+        URL url = this.getClass().getResource("/worldpay-single/worldpay-bin-ranges-single.csv");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
 
         CardInformationStore cardInformationStore = mock(CardInformationStore.class);
         worldpayBinRangeLoader.loadDataTo(cardInformationStore);

--- a/src/test/java/uk/gov/pay/card/db/loader/BinRangeDataLoaderTest.java
+++ b/src/test/java/uk/gov/pay/card/db/loader/BinRangeDataLoaderTest.java
@@ -21,48 +21,23 @@ public class BinRangeDataLoaderTest {
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
-
-    @Test
-    public void shouldLoadWorldpayBinRangesFromFile() throws Exception {
-
-        URL url = this.getClass().getResource("/worldpay/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
-
-        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
-        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
-
-        verify(cardInformationStore, times(5)).put(any(CardInformation.class));
-    }
-
     @Test
     public void shouldLoadWorldpayBinRangesFromURL() throws Exception {
 
         URL url = this.getClass().getResource("/worldpay/worldpay-bin-ranges.csv");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
 
         CardInformationStore cardInformationStore = mock(CardInformationStore.class);
         worldpayBinRangeLoader.loadDataTo(cardInformationStore);
 
         verify(cardInformationStore, times(5)).put(any(CardInformation.class));
-    }
-
-    @Test
-    public void shouldLoadDiscoverBinRangesFromFile() throws Exception {
-
-        URL url = this.getClass().getResource("/discover/");
-        BinRangeDataLoader discoverBinRangeLoader = BinRangeDataLoaderFactory.discover(url.getFile());
-
-        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
-        discoverBinRangeLoader.loadDataTo(cardInformationStore);
-
-        verify(cardInformationStore, times(3)).put(any(CardInformation.class));
     }
 
     @Test
     public void shouldLoadDiscoverBinRangesFromURL() throws Exception {
 
         URL url = this.getClass().getResource("/discover/discover-bin-ranges.csv");
-        BinRangeDataLoader discoverBinRangeLoader = BinRangeDataLoaderFactory.discover(url.toString());
+        BinRangeDataLoader discoverBinRangeLoader = BinRangeDataLoaderFactory.discover(url);
 
         CardInformationStore cardInformationStore = mock(CardInformationStore.class);
         discoverBinRangeLoader.loadDataTo(cardInformationStore);
@@ -71,23 +46,9 @@ public class BinRangeDataLoaderTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenNoFileIsFound() throws Exception {
-
-        URL url = this.getClass().getResource("/empty/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
-
-        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
-        exception.expect(BinRangeDataLoader.DataLoaderException.class);
-
-        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
-
-        verifyZeroInteractions(cardInformationStore);
-    }
-
-    @Test
     public void shouldThrowExceptionWhenURLDoesNotExist() throws Exception {
 
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay("file:///nonexistent/path");
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(new URL("file:///nonexistent/path"));
 
         CardInformationStore cardInformationStore = mock(CardInformationStore.class);
         exception.expect(BinRangeDataLoader.DataLoaderException.class);
@@ -95,38 +56,12 @@ public class BinRangeDataLoaderTest {
         worldpayBinRangeLoader.loadDataTo(cardInformationStore);
 
         verifyZeroInteractions(cardInformationStore);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenMoreThanOneFileIsFound() throws Exception {
-
-        URL url = this.getClass().getResource("/multiple-files/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
-
-        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
-        exception.expect(BinRangeDataLoader.DataLoaderException.class);
-
-        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
-
-        verifyZeroInteractions(cardInformationStore);
-    }
-
-    @Test
-    public void shouldLoadBinRangeDataAsCardInformationFromFile() throws Exception {
-        URL url = this.getClass().getResource("/worldpay-single/");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.getFile());
-
-        CardInformationStore cardInformationStore = mock(CardInformationStore.class);
-        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
-
-        CardInformation expectedCardInformation = new CardInformation("ELECTRON", "D", "ELECTRON", 511226111L, 511226200L, false, PrepaidStatus.PREPAID);
-        verify(cardInformationStore).put(expectedCardInformation);
     }
 
     @Test
     public void shouldLoadBinRangeDataAsCardInformationFromURL() throws Exception {
         URL url = this.getClass().getResource("/worldpay-single/worldpay-bin-ranges-single.csv");
-        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url.toString());
+        BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(url);
 
         CardInformationStore cardInformationStore = mock(CardInformationStore.class);
         worldpayBinRangeLoader.loadDataTo(cardInformationStore);

--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
@@ -21,9 +21,9 @@ public class CardIdResourceITest {
             , resourceFilePath("config/config.yaml")
             , config("server.applicationConnectors[0].port", "0")
             , config("server.adminConnectors[0].port", "0")
-            , config("worldpayDataLocation", "data/sources/worldpay/")
-            , config("discoverDataLocation", "data/sources/discover/")
-            , config("testCardDataLocation", "data/sources/test-cards/"));
+            , config("worldpayDataLocation", "file://" + System.getProperty("user.dir") + "/data/sources/worldpay/GENERIC2ISOCPTISSUERPREPAID.CSV")
+            , config("discoverDataLocation", "file://" + System.getProperty("user.dir") + "/data/sources/discover/Merchant_Marketing.csv")
+            , config("testCardDataLocation", "file://" + System.getProperty("user.dir") + "/data/sources/test-cards/test-card-bin-ranges.csv"));
 
     @Test
     public void shouldFindDiscoverCardInformation() {


### PR DESCRIPTION
## WHAT YOU DID
We only ever support loading a single file for each of the BIN range sources, however we specify a directory to load these files from.

If there's not exactly one file in the specified directory we throw an error, so why not specify the filename directly?

Even better, let's make these URLs so that we can potentially download them on startup and don't need to rely on the data being burnt into the container.