### PR TITLE
Support loading BIN range data from S3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>utils</artifactId>
             <version>1.0.20190726101441</version>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.11.519</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/src/main/java/uk/gov/pay/card/app/config/CardConfiguration.java
+++ b/src/main/java/uk/gov/pay/card/app/config/CardConfiguration.java
@@ -3,18 +3,19 @@ package uk.gov.pay.card.app.config;
 import io.dropwizard.Configuration;
 
 import javax.validation.constraints.NotNull;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 public class CardConfiguration extends Configuration {
 
     @NotNull
-    private URL worldpayDataLocation;
+    private String worldpayDataLocation;
 
     @NotNull
-    private URL discoverDataLocation;
+    private String discoverDataLocation;
 
     @NotNull
-    private URL testCardDataLocation;
+    private String testCardDataLocation;
 
     @NotNull
     private String graphiteHost;
@@ -23,15 +24,27 @@ public class CardConfiguration extends Configuration {
     private String graphitePort;
 
     public URL getDiscoverDataLocation() {
-        return discoverDataLocation;
+        try {
+            return new URL(discoverDataLocation);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public URL getWorldpayDataLocation() {
-        return worldpayDataLocation;
+        try {
+            return new URL(worldpayDataLocation);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public URL getTestCardDataLocation() {
-        return testCardDataLocation;
+        try {
+            return new URL(testCardDataLocation);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public String getGraphiteHost() {


### PR DESCRIPTION
## WHAT YOU DID
Now that we support loading BIN range data from arbitrary URLs, add in special handling for loading from S3

Note that if we don't use this, we shouldn't merge it because dependabot will gleefully raise PRs every time AWS release an updated S3 client