### PR TITLE
Add a healthcheck for the card information store

### DIFF
--- a/src/main/java/uk/gov/pay/card/db/CardInformationStore.java
+++ b/src/main/java/uk/gov/pay/card/db/CardInformationStore.java
@@ -11,6 +11,8 @@ public interface CardInformationStore {
 
     void initialiseCardInformation() throws Exception;
 
+    boolean isReady();
+
     void put(CardInformation cardInformation);
 
     Optional<CardInformation> find(String prefix);

--- a/src/main/java/uk/gov/pay/card/db/RangeSetCardInformationStore.java
+++ b/src/main/java/uk/gov/pay/card/db/RangeSetCardInformationStore.java
@@ -22,6 +22,7 @@ public class RangeSetCardInformationStore implements CardInformationStore {
     private final List<BinRangeDataLoader> binRangeLoaders;
     private final RangeSet<Long> rangeSet;
     private final ConcurrentHashMap<Range, CardInformation> store;
+    private boolean loaded;
 
     public RangeSetCardInformationStore(List<BinRangeDataLoader> binRangeLoaders) {
         this.binRangeLoaders = binRangeLoaders;
@@ -34,6 +35,11 @@ public class RangeSetCardInformationStore implements CardInformationStore {
         for (BinRangeDataLoader loader : binRangeLoaders) {
             loader.loadDataTo(this);
         }
+        loaded = true;
+    }
+
+    @Override public boolean isReady() {
+        return loaded;
     }
 
     @Override


### PR DESCRIPTION
We should not report that we are healthy until all data records have been
loaded into the card information store.

Add a healthcheck to indicate this.

The healthcheck name is 'informationstore'

Retire the 'ping' healthcheck as it now provides no additional value.
