### PR TITLE
Add a HEALTHCHECK to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM adoptopenjdk/openjdk11@sha256:eaa182283f19d3f0ee0c6217d29e299bb4056d379244ce957e30dcdc9e278e1e
 
 RUN ["apk", "--no-cache", "upgrade"]
-RUN ["apk", "--no-cache", "add", "tini"]
+RUN ["apk", "--no-cache", "add", "tini", "curl"]
 
 ARG DNS_TTL=15
 
@@ -22,6 +22,8 @@ WORKDIR /app
 COPY data/sources/ /app/data/
 COPY target/*.yaml /app/
 COPY target/pay-*-allinone.jar /app/
+
+HEALTHCHECK --interval=20s --timeout=3s --start-period=30s CMD curl -A "curl (pay-cardid Dockerfile healthcheck; localhost:$PORT)" -sf "http://localhost:$PORT/healthcheck" || exit 1
 
 ENTRYPOINT ["tini", "-e", "143", "--"]
 


### PR DESCRIPTION
curl isn't the greatest thing to use here because with -f it doesn't output
anything on failure, so if the healthcheck fails you don't get to see the JSON
from the healthcheck endpoint in 'docker inspect' (you will see it for a
successful healthcheck)

This directive is respected by Docker, Docker Compose and AWS ECS.

'docker inspect' output will look something like this for a failing healthcheck:
```
   [
       {
   [...]
           "State": {
   [...]
               "Health": {
                   "Status": "unhealthy",
                   "FailingStreak": 0,
                   "Log": [
                       {
                           "Start": "2019-08-10T10:50:39.9300904Z",
                           "End": "2019-08-10T10:50:40.3198947Z",
                           "ExitCode": 1,
                           "Output": ""
                       }
                   ]
```