### PR TITLE
Stop running zap tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
                 }
             }
             steps {
-                runAppE2E("cardid", "card,zap")
+                runAppE2E("cardid", "card")
             }
         }
       }


### PR DESCRIPTION
cardid is very unlikely to lead to any kind of XSS or SQLi vulnerability in
frontend without some kind of change to frontend.

Stop running zap tests when cardid changes are made.