### PR TITLE
REP-190: Stop throwing 500s for short card numbers

### DIFF
--- a/src/main/java/uk/gov/pay/card/service/CardService.java
+++ b/src/main/java/uk/gov/pay/card/service/CardService.java
@@ -1,15 +1,13 @@
 package uk.gov.pay.card.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.pay.card.db.CardInformationStore;
 import uk.gov.pay.card.model.CardInformation;
 
 import java.util.Optional;
 
-public class CardService {
+import static uk.gov.pay.card.db.CardInformationStore.CARD_RANGE_LENGTH;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CardService.class);
+public class CardService {
 
     private final CardInformationStore cardInformationStore;
 
@@ -18,9 +16,9 @@ public class CardService {
     }
 
     public Optional<CardInformation> getCardInformation(String cardNumber) {
-        if (cardNumber.length() < CardInformationStore.CARD_RANGE_LENGTH) {
-            LOGGER.error("Received card number with fewer than {} characters", CardInformationStore.CARD_RANGE_LENGTH);
-        }
-        return cardInformationStore.find(cardNumber.substring(0, CardInformationStore.CARD_RANGE_LENGTH));
+        return cardInformationStore.find(cardNumber.length() > CARD_RANGE_LENGTH
+                ? cardNumber.substring(0, CARD_RANGE_LENGTH)
+                : cardNumber);
     }
+
 }

--- a/src/test/java/uk/gov/pay/card/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/card/service/CardServiceTest.java
@@ -1,39 +1,44 @@
 package uk.gov.pay.card.service;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.card.db.CardInformationStore;
 import uk.gov.pay.card.model.CardInformation;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CardServiceTest {
+    @Mock
+    CardInformationStore cardInformationStore;
 
-    private final CardInformationStore cardInformationStore = mock(CardInformationStore.class);
+    @Test
+    public void testShortCardNumber() {
+        Optional<CardInformation> cardInfo = Optional.of(new CardInformation("dummy", "C", "dummy", 0L, 0L));
+        when(cardInformationStore.find("00")).thenReturn(cardInfo);
 
-    private CardService cardService;
-
-    @Before
-    public void setup() {
-        cardService = new CardService(cardInformationStore);
+        assertThat(new CardService(cardInformationStore).getCardInformation("00"), is(cardInfo));
     }
 
     @Test
-    public void shouldStripTheCardNumberTo11DigitsForBinRangeLookup() {
+    public void test11DigitCardNumber() {
+        Optional<CardInformation> cardInfo = Optional.of(new CardInformation("dummy", "C", "dummy", 0L, 0L));
+        when(cardInformationStore.find("12345678901")).thenReturn(cardInfo);
 
-        CardInformation expectedCardInformation = new CardInformation("visa", "D", "visa", 11000L, 13000L);
-        when(cardInformationStore.find("12345678901")).thenReturn(Optional.of(expectedCardInformation));
+        assertThat(new CardService(cardInformationStore).getCardInformation("12345678901"), is(cardInfo));
+    }
 
-        Optional<CardInformation> cardInformation = cardService.getCardInformation("1234567890123456");
+    @Test
+    public void test12DigitCardNumberIsTruncated() {
+        Optional<CardInformation> cardInfo = Optional.of(new CardInformation("dummy", "C", "dummy", 0L, 0L));
+        when(cardInformationStore.find("12345678901")).thenReturn(cardInfo);
 
-        assertTrue(cardInformation.isPresent());
-        assertEquals(expectedCardInformation, cardInformation.get());
-        verify(cardInformationStore).find("12345678901");
+        assertThat(new CardService(cardInformationStore).getCardInformation("123456789012"), is(cardInfo));
     }
 }


### PR DESCRIPTION
If you pass a card number with fewer than 11 characters to cardid, it throws an
internal server error.

e.g.

    curl -v -X POST -H 'Content-Type: application/json' -d '{ "cardNumber": "4"}' http://localhost:8080/v1/api/card

This is because we call substring(0, 11) on the cardnumber string, which throws
a java.lang.StringIndexOutOfBoundsException on strings shorter than 11
characters.

Make this more robust and return 404 instead.

We already test CardInformationStore quite thoroughly so the only functionality
in CardService we need to test is that the lookup key gets truncated
appropriately.

Move this logic to a separate method and test that specifically.