### PR TITLE
Prevent browser content type sniffing of the healthcheck response

### DIFF
--- a/src/main/java/uk/gov/pay/card/resources/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/card/resources/HealthCheckResource.java
@@ -43,7 +43,7 @@ public class HealthCheckResource {
 
         Response.Status status = allHealthy(results.values()) ? OK : SERVICE_UNAVAILABLE;
 
-        return status(status).entity(response).build();
+        return status(status).entity(response).header("X-Content-Type-Options", "nosniff").build();
     }
 
     private boolean allHealthy(Collection<HealthCheck.Result> results) {


### PR DESCRIPTION
This isn't really needed, but it got picked up by the Zap scanner and we know
we're serving JSON so we might as well set this header to prevent browser
content type sniffing.

Add the following header to healthcheck responses:

    X-Content-Type-Options: nosniff
