### PR TITLE
BAU Add stacktraceAppPackage config for Sentry

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -27,6 +27,7 @@ logging:
       threshold: ERROR
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
       environment: ${ENVIRONMENT}
+      stacktraceAppPackages: ["uk.gov.pay"]
 
 worldpayDataLocation: ${WORLDPAY_DATA_LOCATION:-file:///app/data/worldpay/GENERIC2ISOCPTISSUERPREPAID.CSV}
 discoverDataLocation: ${DISCOVER_DATA_LOCATION:-file:///app/data/discover/Merchant_Marketing.csv}


### PR DESCRIPTION
This is used to tell Sentry which stack frames relate to our application
versus those from standard libraries/frameworks. Sentry docs recommend
this is set at
https://docs.sentry.io/clients/java/config/#in-application-stack-frames

This has been set as per the documentation for the sentry dropwizard
appender at https://github.com/dhatim/dropwizard-sentry
