### PR TITLE
PP-6001 Upgrade dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.3.17</dropwizard.version>
+        <dropwizard.version>2.0.0</dropwizard.version>
         <hamcrest.version>2.2</hamcrest.version>
         <jmh.version>1.22</jmh.version>
         <jackson.version>2.10.1</jackson.version>
-        <pay-java-commons.version>1.0.20191127134754</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20200107160358</pay-java-commons.version>
     </properties>
 
     <repositories>
@@ -24,6 +24,12 @@
             <url>https://dl.bintray.com/govuk-pay/pay-java-commons</url>
         </repository>
     </repositories>
+
+    <parent>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-dependencies</artifactId>
+        <version>2.0.0</version>
+    </parent>
 
     <dependencies>
         <dependency>
@@ -64,7 +70,7 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>1.3.9-2</version>
+            <version>2.0.0-3</version>
         </dependency>
 
         <!-- testing -->


### PR DESCRIPTION
## WHAT
- Upgrades dropwizard to v2.0.0
- Dropwizard 2.0.0 upgrade doesn't specify transitive dependency versions anymore https://www.dropwizard.io/en/release-2.0.x/manual/upgrade-notes/upgrade-notes-2_0_x.html
Add parent `dropwizard-dependencies` which has versions of transitive dependencies specified and can be overridden.

    We can also include BOM for transitive dependency versions but versions can't be overridden and we may end up with multiple revisions of same library. For example, `jackson-version` current used is `2.10.2` but dropwizard uses `2.10.1`

- Upgraded dropwizard-sentry library too without which builds are failing with error `java.lang.NoSuchMethodError: 'com.google.common.collect.ImmutableList org.dhatim.dropwizard.sentry.logging.SentryAppenderFactory.getFilterFactories()'`

- Upgrade pay-java-commons library which is on dropwizard v2.0.0 and defines required library `org.glassfish.jersey.bundles.repackaged`

