### PR TITLE
PP-6029 Add java buildpack manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,3 @@
+memory: 500M
+disk_quota: 500M
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,26 @@
+---
+applications:
+  - name: cardid
+    buildpacks:
+      - java_buildpack
+    path: target/pay-cardid-0.1-SNAPSHOT-allinone.jar
+    health-check-type: http
+    health-check-http-endpoint: '/healthcheck'
+    health-check-invocation-timeout: 5
+    memory: ((memory))
+    disk_quota: ((disk_quota))
+    env:
+      ADMIN_PORT: '9801'
+      ENVIRONMENT: ((space))
+      JAVA_OPTS: -Xms512m -Xmx1G
+      JBP_CONFIG_JAVA_MAIN: '{ arguments: "server /home/vcap/app/config/config.yaml" }'
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+
+      AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
+
+      # Provide via Sentry service
+      SENTRY_DSN: noop://localhost
+
+      RUN_APP: 'true'
+    routes:
+      - route: ((cardid_internal_route))


### PR DESCRIPTION
Adds a java buildpack manifest and dev.yml with common development
environment variables. To deploy into a PaaS space log into the space
and run the following from this project's root:

```
cf push --vars-file dev.yml \
  --var space=<space> \
  --var cardid_internal_route=cardid-<space>.apps.internal \
  --var cardid_public_route=pay-cardid-<space>.london.cloudapps.digital
```
**How to test**
Push to your dev space. If its the first time you may need to delete the existing docker image based app with `cf delete cardid`.

