### PR TITLE
PP-6128 Add data locations to manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -17,10 +17,11 @@ applications:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
 
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
+      TEST_CARD_DATA_LOCATION: ((test_card_data_location))
+      WORLDPAY_DATA_LOCATION: ((worldpay_data_location))
+      DISCOVER_DATA_LOCATION: ((discover_data_location))
 
       # Provide via Sentry service
       SENTRY_DSN: noop://localhost
 
       RUN_APP: 'true'
-    routes:
-      - route: ((cardid_internal_route))


### PR DESCRIPTION
When running on PaaS Cardid will read the bin range data from a service
named cardid-data. This change adds the env vars which will be set per
space to point to the cardid-data app.

Also, remove defining the route within the manifest since it is set by
terraform when the space is created.

## WHAT YOU DID
Tested by pushing this manually into our staging-cde space
```
gds5062 > cf push --vars-file /Users/danworth/projects/gds/pay-omnibus/paas/env_variables/staging.yml

     state     since                  cpu    memory         disk           details
#0   running   2020-02-07T14:41:04Z   0.0%   420.7M of 1G   260.9M of 1G
```