### PR TITLE
PP-6254 Add carbon relay

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -23,6 +23,10 @@ applications:
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
       RUN_APP: 'true'
 
+      # Provided via the app-catalog service, see env-map.yml
+      METRICS_HOST: ""
+      METRICS_PORT: ""
+
       # Provided via cardid-secret-service see env-map.yml
       TEST_CARD_DATA_LOCATION: ""
       WORLDPAY_DATA_LOCATION: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -2,4 +2,6 @@ env_vars:
   TEST_CARD_DATA_LOCATION:  '.[][] | select(.name == "app-catalog")           | .credentials.cardid_data_test_card_data_location'
   WORLDPAY_DATA_LOCATION:   '.[][] | select(.name == "app-catalog")           | .credentials.cardid_data_worldpay_data_location'
   DISCOVER_DATA_LOCATION:   '.[][] | select(.name == "app-catalog")           | .credentials.cardid_data_discover_data_location'
+  METRICS_HOST:             '.[][] | select(.name == "app-catalog")           | .credentials.carbon_relay_route'
+  METRICS_PORT:             '.[][] | select(.name == "app-catalog")           | .credentials.carbon_relay_port'
   SENTRY_DSN:               '.[][] | select(.name == "cardid-secret-service") | .credentials.sentry_dsn'


### PR DESCRIPTION
Set the METRICS_HOST and METRICS_PORT from the app-catalog to send
metrics to the carbon-relay app.
