### PR TITLE
PP-6561 Fix mvn verify phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,15 @@
                 <version>3.1.2</version>
                 <executions>
                     <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>false</failOnWarning>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-dependencies</id>
                         <phase>package</phase>
                         <goals>


### PR DESCRIPTION
The pom references the `dropwizard-dependencies` pom v2.0.10 as a parent which
includes an execution rule for `maven-dependency-plugin:analyze-only`
setting the `failOnWarning` to `true` (the default is false). This plugin is
run as part of the `verify` phase. We have undeclared transitive dependencies so the
`analyze-only` goal fails and consquently the build.

This isn't a problem on Jenkins because it runs `mvn package` for cardid
and not `mvn verify` as per all other apps. By fixing this we can test
all java apps in the same manner.

The result of the pom inheritence can be viewed by running `mvn
help:effective-pom`. Earlier versions of the dropwizard pom
used by connector do not introduce the execution rule with
`failOnWarning` true, though this change may be necessary for those
projects. We should also consider whether we ought to declare transitive
dependencies in our pom.

## WHAT YOU DID
We want to test all java apps the same way to avoid carrying over discrepancies onto concourse ci pipeline.

run `mvn clean verify` and it should pass. You can check the combined pom running `mvn help:effective-pom` and see that the `maven-dependency-plugin:analyze-only` goal has config showing `failOnWarning = false`

We should consider declaring transitive dependencies and we could move some of the "declared but unused" dependencies into `runtime` scope, though wanted to keep that change separate. To see these warnings either run `mvn verify` or more specifically `mvn dependency:analyze`, here is what you'll get
```
[WARNING] Used undeclared dependencies found:
[WARNING]    junit:junit:jar:4.13:compile
[WARNING]    org.hibernate.validator:hibernate-validator:jar:6.1.5.Final:compile
[WARNING]    io.dropwizard:dropwizard-configuration:jar:2.0.10:compile
[WARNING]    jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
[WARNING]    jakarta.servlet:jakarta.servlet-api:jar:4.0.3:compile
[WARNING]    io.dropwizard:dropwizard-lifecycle:jar:2.0.10:compile
[WARNING]    org.slf4j:slf4j-api:jar:1.7.30:compile
[WARNING]    com.fasterxml.jackson.core:jackson-core:jar:2.11.1:compile
[WARNING]    io.dropwizard:dropwizard-jersey:jar:2.0.10:compile
[WARNING]    jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
[WARNING]    io.dropwizard:dropwizard-jetty:jar:2.0.10:compile
[WARNING]    io.dropwizard.metrics:metrics-healthchecks:jar:4.1.9:compile
[WARNING] Unused declared dependencies found:
[WARNING]    ch.qos.logback:logback-classic:jar:1.2.3:compile
[WARNING]    uk.gov.pay:utils:jar:1.0.20200702150539:compile
[WARNING]    org.dhatim:dropwizard-sentry:jar:2.0.0-5:compile
[WARNING]    org.hamcrest:hamcrest-library:jar:2.2:test
[WARNING]    org.openjdk.jmh:jmh-generator-annprocess:jar:1.23:provided
[WARNING]    javax.xml.bind:jaxb-api:jar:2.3.1:compile
```