### PR TITLE
PP-6561 DO NOT MERGE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "data"]
 	path = data
-	url = git@github.com:alphagov/pay-cardid-data.git
+	url = ../pay-cardid-data.git
 	branch = master


### PR DESCRIPTION
Concourse git pr resource clones cardid using https oauth yet the submodule path is
specified for ssh which we suspect causes problems when the same git pr resource
attempts to clone it as it doesn't have an appropriate private key.

It's possible to use a relative path so that the
submodule should be cloned using the same protocol as that which was
used to clone cardid itself. Trying it out.

## WHAT YOU DID
Trying this out, do not merge or bother to review yet.