### PR TITLE
Remove uk.gov.pay.utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,6 @@
             <version>1.2.3</version>
         </dependency>
         <dependency>
-            <groupId>uk.gov.pay</groupId>
-            <artifactId>utils</artifactId>
-            <version>1.0.20201103173727</version>
-        </dependency>
-        <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.0.12-1</version>


### PR DESCRIPTION
This is no longer used as of Jan 2020's
ed4e86891df4afd6a54edfeb4eb43794b845237d

Removing this dependency shrinks the jar from 126MiB to 23MiB by removing the
following transitive dependencies:

- com.amazonaws:aws-xray-recorder-sdk-apache-http
- com.amazonaws:aws-xray-recorder-sdk-aws-sdk
- com.amazonaws:aws-xray-recorder-sdk-aws-sdk-instrumentor
- com.amazonaws:aws-xray-recorder-sdk-core
- com.amazonaws:aws-xray-recorder-sdk-sql-postgres
- io.dropwizard:dropwizard-db
- org.apache.httpcomponents:httpclient
- org.eclipse.persistence:org.eclipse.persistence.jpa

Creating the shaded jar is now much faster for me, reducing the time for 'mvn
clean verify' from 1 minute to ~30 seconds.