### PR TITLE
Convert to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jmh.version>1.26</jmh.version>
         <jackson.version>2.11.3</jackson.version>
+        <mockito.version>3.6.0</mockito.version>
         <pay-java-commons.version>1.0.20201103173727</pay-java-commons.version>
     </properties>
 
@@ -67,6 +68,11 @@
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.0.12-1</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>
@@ -90,7 +96,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.6.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -122,9 +128,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
+++ b/src/test/java/uk/gov/pay/card/db/RangeSetCardInformationStoreTest.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.card.db;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.card.db.loader.BinRangeDataLoader;
 import uk.gov.pay.card.model.CardType;
 import uk.gov.pay.card.model.CardInformation;
@@ -12,20 +12,20 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.card.db.loader.BinRangeDataLoader.BinRangeDataLoaderFactory;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RangeSetCardInformationStoreTest {
 
     private CardInformationStore cardInformationStore;
 
-    @After
+    @AfterEach
     public void tearDown() {
         cardInformationStore.destroy();
     }

--- a/src/test/java/uk/gov/pay/card/db/loader/BinRangeDataLoaderTest.java
+++ b/src/test/java/uk/gov/pay/card/db/loader/BinRangeDataLoaderTest.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.card.db.loader;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.card.db.CardInformationStore;
 import uk.gov.pay.card.db.loader.BinRangeDataLoader.BinRangeDataLoaderFactory;
 import uk.gov.pay.card.model.CardInformation;
@@ -10,6 +8,7 @@ import uk.gov.pay.card.model.PrepaidStatus;
 
 import java.net.URL;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -17,9 +16,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class BinRangeDataLoaderTest {
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void shouldLoadWorldpayBinRangesFromURL() throws Exception {
@@ -51,9 +47,8 @@ public class BinRangeDataLoaderTest {
         BinRangeDataLoader worldpayBinRangeLoader = BinRangeDataLoaderFactory.worldpay(new URL("file:///nonexistent/path"));
 
         CardInformationStore cardInformationStore = mock(CardInformationStore.class);
-        exception.expect(BinRangeDataLoader.DataLoaderException.class);
 
-        worldpayBinRangeLoader.loadDataTo(cardInformationStore);
+        assertThrows(BinRangeDataLoader.DataLoaderException.class, () -> worldpayBinRangeLoader.loadDataTo(cardInformationStore));
 
         verifyZeroInteractions(cardInformationStore);
     }

--- a/src/test/java/uk/gov/pay/card/db/loader/WorldpayPrepaidParserTest.java
+++ b/src/test/java/uk/gov/pay/card/db/loader/WorldpayPrepaidParserTest.java
@@ -1,16 +1,12 @@
 package uk.gov.pay.card.db.loader;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.card.model.PrepaidStatus;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 public class WorldpayPrepaidParserTest {
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void shouldReturnPrepaidForY() {

--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.card.it.resources;
 
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.pay.card.app.CardApi;
 import uk.gov.pay.card.app.config.CardConfiguration;
 
@@ -15,26 +16,26 @@ import static org.hamcrest.core.Is.is;
 
 /**
  * @deprecated The usefulness of many of these tests is unclear - move them to pay-cardid-data?
- *
+ * <p>
  * These tests used to make assertions about data in pay-cardid-data, but that lives in a private repo.
- *
+ * <p>
  * We want to be able to test pay-cardid in a CI system that doesn't have access to private repos,
  * so the data needed for the tests to pass has been redacted to reduce its sensitivity and inlined
  * in src/test/resources/card-id-resource-integration-test
- *
+ * <p>
  * The overall effect is that a lot of these tests are now just checking that "the tests do what the tests do",
  * whereas they used to make some (fairly loose) assertions that the bin data in pay-cardid-data was correct.
- *
+ * <p>
  * If we care about testing pay-cardid-data we should set up CI for that repo separately in a system that
  * has access to private repos and move the tests that use card data there.
- *
+ * <p>
  * A test that checks the general success case and the tests for the error conditions without relying on specific
  * card details are probably still valid and should stay.
  */
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class CardIdResourceITest {
 
-    @Rule
-    public final DropwizardAppRule<CardConfiguration> app = new DropwizardAppRule<>(
+    private static final DropwizardAppExtension<CardConfiguration> app = new DropwizardAppExtension<>(
             CardApi.class
             , resourceFilePath("config/config.yaml")
             , config("server.applicationConnectors[0].port", "0")

--- a/src/test/java/uk/gov/pay/card/model/CardInformationTest.java
+++ b/src/test/java/uk/gov/pay/card/model/CardInformationTest.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.card.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CardInformationTest {
 

--- a/src/test/java/uk/gov/pay/card/model/CardTypeTest.java
+++ b/src/test/java/uk/gov/pay/card/model/CardTypeTest.java
@@ -1,15 +1,11 @@
 package uk.gov.pay.card.model;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CardTypeTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldFindCardClass() {
@@ -19,15 +15,25 @@ public class CardTypeTest {
 
     @Test
     public void shouldThrowNullPointerException_WhenNullValuePassed_forCardClass() {
-        thrown.expect(java.lang.NullPointerException.class);
-        thrown.expectMessage("Value cannot be null for paymentGatewayRepresentation");
-        new CardInformation("A", null, "A", 1L, 2L);
+        try {
+            new CardInformation("A", null, "A", 1L, 2L);
+            fail("The constructor was expected to throw an exception");
+        } catch (NullPointerException e) {
+            assertEquals("Value cannot be null for paymentGatewayRepresentation", e.getMessage());
+        } catch (Throwable e) {
+            fail("An unexpected exception was thrown by the constructor: " + e);
+        }
     }
 
     @Test
     public void shouldThrowIllegalArgumentException_WhenInvalidValuePassed_forCardClass() {
-        thrown.expect(java.lang.IllegalArgumentException.class);
-        thrown.expectMessage("No enum found for value [I do not exist]");
-        new CardInformation("A", "I do not exist", "A", 1L, 2L);
+        try {
+            new CardInformation("A", "I do not exist", "A", 1L, 2L);
+            fail("The constructor was expected to throw an exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("No enum found for value [I do not exist]", e.getMessage());
+        } catch (Throwable e) {
+            fail("An unexpected exception was thrown by the constructor: " + e);
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/card/resources/HealthCheckResourceTest.java
+++ b/src/test/java/uk/gov/pay/card/resources/HealthCheckResourceTest.java
@@ -7,11 +7,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.jayway.jsonassert.JsonAssert;
 import io.dropwizard.setup.Environment;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.core.Response;
 import java.util.SortedMap;
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HealthCheckResourceTest {
     @Mock
     private Environment environment;
@@ -32,7 +32,7 @@ public class HealthCheckResourceTest {
 
     private HealthCheckResource resource;
 
-    @Before
+    @BeforeEach
     public void setup() {
         when(environment.healthChecks()).thenReturn(healthCheckRegistry);
         resource = new HealthCheckResource(environment);

--- a/src/test/java/uk/gov/pay/card/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/card/service/CardServiceTest.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.card.service;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.card.db.CardInformationStore;
 import uk.gov.pay.card.model.CardInformation;
 
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CardServiceTest {
     @Mock
     CardInformationStore cardInformationStore;


### PR DESCRIPTION
Replace an implied JUnit 4 with an explicit JUnit 5 Jupiter.

This was mostly straightforward, with the only real change being to adjust
tests for expecting certain exceptions (unfortunately `assertThrows` doesn't
have the facility to match the exception message, just its type).

CardIdResourceITest seems about 5 seconds quicker now.

_Originally contributed by @rhowe in https://github.com/alphagov/pay-cardid/pull/475._