### PR TITLE
BAU — Use assertThrows in tests that assert exception messages

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,75 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-11-10T09:39:42Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java": [
+      {
+        "hashed_secret": "7e0a1242bd8ef9044f27dca45f5f72ad5a1125bf",
+        "is_verified": false,
+        "line_number": 133,
+        "type": "Hex High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/src/test/java/uk/gov/pay/card/model/CardTypeTest.java
+++ b/src/test/java/uk/gov/pay/card/model/CardTypeTest.java
@@ -2,38 +2,31 @@ package uk.gov.pay.card.model;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CardTypeTest {
 
     @Test
-    public void shouldFindCardClass() {
-        CardInformation cardInformation = new CardInformation("A", "C", "A", 1L, 2L);
+    void shouldFindCardClass() {
+        var cardInformation = new CardInformation("A", "C", "A", 1L, 2L);
         assertEquals(CardType.CREDIT, cardInformation.getCardType());
     }
 
     @Test
-    public void shouldThrowNullPointerException_WhenNullValuePassed_forCardClass() {
-        try {
-            new CardInformation("A", null, "A", 1L, 2L);
-            fail("The constructor was expected to throw an exception");
-        } catch (NullPointerException e) {
-            assertEquals("Value cannot be null for paymentGatewayRepresentation", e.getMessage());
-        } catch (Throwable e) {
-            fail("An unexpected exception was thrown by the constructor: " + e);
-        }
+    void shouldThrowNullPointerException_WhenNullValuePassed_forCardClass() {
+        var thrown = assertThrows(NullPointerException.class,
+                () -> new CardInformation("A", null, "A", 1L, 2L));
+        assertThat(thrown.getMessage(), is("Value cannot be null for paymentGatewayRepresentation"));
     }
 
     @Test
-    public void shouldThrowIllegalArgumentException_WhenInvalidValuePassed_forCardClass() {
-        try {
-            new CardInformation("A", "I do not exist", "A", 1L, 2L);
-            fail("The constructor was expected to throw an exception");
-        } catch (IllegalArgumentException e) {
-            assertEquals("No enum found for value [I do not exist]", e.getMessage());
-        } catch (Throwable e) {
-            fail("An unexpected exception was thrown by the constructor: " + e);
-        }
+    void shouldThrowIllegalArgumentException_WhenInvalidValuePassed_forCardClass() {
+        var thrown = assertThrows(IllegalArgumentException.class,
+                () -> new CardInformation("A", "I do not exist", "A", 1L, 2L));
+        assertThat(thrown.getMessage(), is("No enum found for value [I do not exist]"));
     }
+
 }


### PR DESCRIPTION
In JUnit 5, `assertThrows` returns the thrown exception so we can assert on it. This is nicer than using `try`/`catch`.