### PR TITLE
Remove logback-classic dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.0.12-1</version>


### PR DESCRIPTION
Our code does not depend on this library.

Dropwizard does, however, but dropwizard-core correctly declares a dependency
on logback-classic 1.2.3 so we should remove this dependency lest an
overly-keen dependency-bumping robot tempt someone into introducing an
incompatible version of logback which breaks Dropwizard.