### PR TITLE
Remove JAXB dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,6 @@
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.0.12-1</version>
         </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
 
         <!-- testing -->
         <dependency>


### PR DESCRIPTION
This isn't needed for runtime and dropwizard-testing and rest-assured both pull
in version 2.3.3.

This results in the following files being removed from the application jar:

```
META-INF/maven/javax.activation/
META-INF/maven/javax.activation/javax.activation-api/
META-INF/maven/javax.activation/javax.activation-api/pom.properties
META-INF/maven/javax.activation/javax.activation-api/pom.xml
META-INF/maven/javax.xml.bind/
META-INF/maven/javax.xml.bind/jaxb-api/
META-INF/maven/javax.xml.bind/jaxb-api/pom.properties
META-INF/maven/javax.xml.bind/jaxb-api/pom.xml
```

as well as removing build warnings about overlapping files when shading the jar