### PR TITLE
BAU remove some unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,19 +59,9 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.0.12-1</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
         </dependency>
 
         <!-- testing -->


### PR DESCRIPTION
- logback: our code does not depend on this library. Dropwizard does, however, but dropwizard-core correctly declares a dependency on logback-classic 1.2.3 so we should remove this dependency lest an overly-keen dependency-bumping robot tempt someone into introducing an incompatible version of logback which breaks Dropwizard.
- jaxb: our code does not depend on this library. Dropwizard does, however, but dropwizard-core correctly declares a dependency on logback-classic 1.2.3 so we should remove this dependency lest a overly-keen dependency-bumping robot tempt someone into introducing an incompatible version of logback which breaks Dropwizard.
reference: https://github.com/alphagov/pay-cardid/pull/483 and https://github.com/alphagov/pay-cardid/pull/482

with @rhowe 
