### PR TITLE
PP-7938 Move Package Coordinates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,19 +12,8 @@
         <jmh.version>1.29</jmh.version>
         <jackson.version>2.12.2</jackson.version>
         <mockito.version>3.8.0</mockito.version>
-        <pay-java-commons.version>1.0.20210310094438</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20210326162042</pay-java-commons.version>
     </properties>
-
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-govuk-pay-pay-java-commons</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/govuk-pay/pay-java-commons</url>
-        </repository>
-    </repositories>
 
     <parent>
         <groupId>io.dropwizard</groupId>
@@ -34,7 +23,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>uk.gov.pay</groupId>
+            <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>

--- a/src/main/java/uk/gov/pay/card/app/CardApi.java
+++ b/src/main/java/uk/gov/pay/card/app/CardApi.java
@@ -16,9 +16,9 @@ import uk.gov.pay.card.managed.CardInformationStoreManaged;
 import uk.gov.pay.card.resources.CardIdResource;
 import uk.gov.pay.card.resources.HealthCheckResource;
 import uk.gov.pay.card.service.CardService;
-import uk.gov.pay.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
-import uk.gov.pay.logging.LoggingFilter;
-import uk.gov.pay.logging.LogstashConsoleAppenderFactory;
+import uk.gov.service.payments.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
+import uk.gov.service.payments.logging.LoggingFilter;
+import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
- As part of the migration from Bintray to Maven Central we must move our coordinates to match the domain we own

- This means that the coordinates of our java packages will now exist under `uk.gov.service.payments` instead of `uk.gov.pay`

- This moves the dependencies of pay-java-commons to maven central from bintray
