### PR TITLE
BAU add dropwizard logging dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.0.20</version>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>


### PR DESCRIPTION
## WHAT YOU DID

- pay-java-commons has a dependency on dropwizard-json-logging. Because pay-java-commons uses its own version of dropwizard, the pay-java-commons version and dropwizard dependency versions for the app need to be updated at the same time to build successfully.

- Add a direct dependency on dropwizard-json-logging so we ignore the version in pay-java-commons and use the version consistent with all the other dropwizard modules.

