### PR TITLE
PP-8695: Remove Jenkins ECS deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,14 +88,6 @@ pipeline {
         }
       }
     }
-    stage('Deploy') {
-      when {
-        branch 'master'
-      }
-      steps {
-        deployEcs("cardid")
-      }
-    }
     stage('Card Payment Smoke Test') {
       when { branch 'master' }
       steps { runCardSmokeTest() }


### PR DESCRIPTION
## WHAT YOU DID
Jenkins doesn't deploy to ECS now and we have now removed the old EC2 based services so the deploy step is no longer required

## How to test

- Only way to test is to merge to master and watch Jenkins fly 😞 

## Code review checklist

### Logging
N/A

### Documentation

N/A