### PR TITLE
PP-9010 Upgrade dropwizard-sentry to 2.0.25-2 and Log4j 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,18 @@
     </parent>
 
     <dependencies>
+        <!-- We do not use log4j-core or log4j-api but some dependencies do
+             and versions before 2.15.0 are vulnerable to CVE-2021-44228 -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.15.0</version>
+        </dependency>
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging</artifactId>
@@ -50,7 +62,7 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>2.0.22</version>
+            <version>2.0.25-2</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
Upgrade dropwizard-sentry from 2.0.22 to the latest 2.0.25-2 but skillfully add a dependency on Log4j 2.15.0 to avoid dropwizard-sentry bringing in a dependency on Log4j 2.14.1, which is vulnerable to CVE-2021-44228.