### PR TITLE
pp-7475 add labels to GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - java
   - govuk-pay
+  - java
 - package-ecosystem: docker
   directory: "/"
   schedule:
@@ -18,10 +18,15 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - java
   - govuk-pay
-- package-ecosystem: "github-actions"
+  - docker
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: daily
     time: "03:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  - govuk-pay
+  - github_actions


### PR DESCRIPTION
## WHAT
Update dependabot config to correctly label github actions