### PR TITLE
PP-9234: Remove end to end tests from jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,22 +58,6 @@ pipeline {
         }
       }
     }
-    stage('Tests') {
-      failFast true
-      stages {
-        stage('End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runAppE2E("cardid", "card,zap")
-            }
-        }
-      }
-    }
     stage('Docker Tag') {
       steps {
         script {


### PR DESCRIPTION
## WHAT YOU DID
Remove end to end tests from jenkins. This requires https://github.com/alphagov/pay-ci/pull/634 to be merged first

## How to test

Check the only change is removing Jenkins E2E tests

## Code review checklist

### Logging

N/A

### Documentation

N/A