### PR TITLE
PP-9406 Fix contract test runner

### DIFF
--- a/src/test/java/uk/gov/pay/card/pact/ConnectorContractTest.java
+++ b/src/test/java/uk/gov/pay/card/pact/ConnectorContractTest.java
@@ -26,9 +26,9 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 @Provider("cardid")
-@PactBroker(url = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}",
+@PactBroker(url = "https://${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}",
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
-        consumerVersionSelectors = @VersionSelector( consumer = "connector", tag = "${PACT_CONSUMER_TAG}", fallbackTag = "test-fargate"))
+        consumerVersionSelectors = @VersionSelector(consumer = "connector", tag = "${PACT_CONSUMER_TAG:}", fallbackTag = "test-fargate"))
 @IgnoreNoPactsToVerify
 @Tag("contract")
 class ConnectorContractTest {
@@ -44,12 +44,16 @@ class ConnectorContractTest {
 
     @BeforeEach
     void before(PactVerificationContext context) {
-        context.setTarget(new HttpTestTarget("localhost", app.getLocalPort(), "/"));
+        if (context != null) {
+            context.setTarget(new HttpTestTarget("localhost", app.getLocalPort(), "/"));
+        }
     }
-    
+
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
     void pactVerificationTestTemplate(PactVerificationContext context) {
-        context.verifyInteraction();
+        if (context != null) {
+            context.verifyInteraction();
+        }
     }
 }


### PR DESCRIPTION
Alter the `url` parameter for the `@PactBroker` annotation to prefix
with "https://", as the the PACT_BROKER_HOST environment variable will
only provide the host name.

Check whether a PactVerificationContext exists in the setup method and
in the TestTemplate method. This will be null if no pacts are found to
verify. This check could be removed once pacts have been uploaded by
connector.