### PR TITLE
PP-10717: Upgrade Docker Java image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:64674afdc275bed87f352eb94f9469842313dd2902afe9d7b0fb9508fc75cc37
+FROM eclipse-temurin:11-jre-alpine@sha256:4edcb9a82ae75460ff836a63d7bf2d601635233130952083f5bc79bf888ea8ad
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "--no-cache", "add", "tini"]

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre@sha256:08a2a85a8c948146f8e052216c5450b5290fe13ab5d3922aeb829b3bf61e08c1
+FROM eclipse-temurin:11-jre@sha256:dd745f7e5a780d432ea24c9936721271e74853c712a58461c47aecd315ef5701
 
 RUN ["apt-get", "update"]
 RUN ["apt-get", "install", "-y", "tini"]


### PR DESCRIPTION
Upgrade image to [jdk 11.0.18](https://hub.docker.com/layers/library/eclipse-temurin/11-jre-alpine/images/sha256-4edcb9a82ae75460ff836a63d7bf2d601635233130952083f5bc79bf888ea8ad?context=explore).

See this [adr](https://github.com/alphagov/pay-architecture/blob/main/adr/024-java-base-image-pinning-strategy.md) on why we only specify the major version.

Alpine doesn't provide an ARM variant of [11.0.18_10-jre-alpine](https://hub.docker.com/layers/library/eclipse-temurin/11.0.18_10-jre-alpine/images/sha256-4edcb9a82ae75460ff836a63d7bf2d601635233130952083f5bc79bf888ea8ad?context=explore) so we've used the latest [eclipse-temurin:11-jre](https://hub.docker.com/layers/library/eclipse-temurin/11-jre/images/sha256-dd745f7e5a780d432ea24c9936721271e74853c712a58461c47aecd315ef5701?context=explore).