### PR TITLE
PP-11010: Update Dockerfile JRE to 11.0.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:49f4597be5839f5aaa389861f2186659a776ff8e726cb7b49fff4c36f30c2d07
+FROM eclipse-temurin:11-jre-alpine@sha256:1a6531a7239bea3739d89d8833b03c7732f51e08ecbb78bbc40ef98287c1212d
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "--no-cache", "add", "tini"]


### PR DESCRIPTION
```
docker run --rm --platform linux/amd64 eclipse-temurin:11-jre-alpine@sha256:1a6531a7239bea3739d89d8833b03c7732f51e08ecbb78bbc40ef98287c1212d java -version
openjdk version "11.0.19" 2023-04-18
OpenJDK Runtime Environment Temurin-11.0.19+7 (build 11.0.19+7)
OpenJDK 64-Bit Server VM Temurin-11.0.19+7 (build 11.0.19+7, mixed mode)
```