### PR TITLE
PP-11223: Set up prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <jackson.version>2.15.2</jackson.version>
         <mockito.version>4.8.0</mockito.version>
         <pay-java-commons.version>1.0.20230720152355</pay-java-commons.version>
+        <prometheus.version>0.16.0</prometheus.version>
         <surefire.version>3.1.2</surefire.version>
         <pact.version>3.6.15</pact.version>
         <PACT_BROKER_URL/>
@@ -30,8 +31,28 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_servlet</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_dropwizard</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging</artifactId>
+            <version>${pay-java-commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.service.payments</groupId>
+            <artifactId>utils</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/card/app/CardApi.java
+++ b/src/main/java/uk/gov/pay/card/app/CardApi.java
@@ -9,6 +9,11 @@ import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
+import io.prometheus.client.exporter.MetricsServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.card.app.config.CardConfiguration;
 import uk.gov.pay.card.db.CardInformationStore;
 import uk.gov.pay.card.db.RangeSetCardInformationStore;
@@ -16,10 +21,12 @@ import uk.gov.pay.card.managed.CardInformationStoreManaged;
 import uk.gov.pay.card.resources.CardIdResource;
 import uk.gov.pay.card.resources.HealthCheckResource;
 import uk.gov.pay.card.service.CardService;
+import uk.gov.service.payments.commons.utils.prometheus.PrometheusDefaultLabelSampleBuilder;
 import uk.gov.service.payments.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
 import uk.gov.service.payments.logging.LoggingFilter;
 import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
 
+import java.net.URI;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -29,6 +36,8 @@ import static uk.gov.pay.card.db.loader.BinRangeDataLoader.BinRangeDataLoaderFac
 
 public class CardApi extends Application<CardConfiguration> {
 
+    private static final Logger logger = LoggerFactory.getLogger(CardApi.class);
+    
     private static final String SERVICE_METRICS_NODE = "cardid";
     private static final int GRAPHITE_SENDING_PERIOD_SECONDS = 10;
 
@@ -59,7 +68,8 @@ public class CardApi extends Application<CardConfiguration> {
             }
         });
 
-        initialiseMetrics(configuration, environment);
+        initialiseGraphiteMetrics(configuration, environment);
+        configuration.getEcsContainerMetadataUriV4().ifPresent(uri -> initialisePrometheusMetrics(environment, uri));
 
         environment.jersey().register(new HealthCheckResource(environment));
         environment.lifecycle().manage(new CardInformationStoreManaged(store));
@@ -69,7 +79,17 @@ public class CardApi extends Application<CardConfiguration> {
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/api/card");
     }
 
-    private void initialiseMetrics(CardConfiguration configuration, Environment environment) {
+    private void initialisePrometheusMetrics(Environment environment, URI ecsContainerMetadataUri) {
+        logger.info("Initialising prometheus metrics.");
+        CollectorRegistry collectorRegistry = new CollectorRegistry();
+        collectorRegistry.register(new DropwizardExports(environment.metrics(), new PrometheusDefaultLabelSampleBuilder(ecsContainerMetadataUri)));
+        environment.admin().addServlet("prometheusMetrics", new MetricsServlet(collectorRegistry)).addMapping("/metrics");
+    }
+
+    /**
+     * Graphtie metric config to be deleted when we've completely moved to Prometheus
+     */
+    private void initialiseGraphiteMetrics(CardConfiguration configuration, Environment environment) {
         GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), configuration.getGraphitePort());
         GraphiteReporter.forRegistry(environment.metrics())
                 .prefixedWith(SERVICE_METRICS_NODE)

--- a/src/main/java/uk/gov/pay/card/app/config/CardConfiguration.java
+++ b/src/main/java/uk/gov/pay/card/app/config/CardConfiguration.java
@@ -1,9 +1,12 @@
 package uk.gov.pay.card.app.config;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 
 import javax.validation.constraints.NotNull;
+import java.net.URI;
 import java.net.URL;
+import java.util.Optional;
 
 public class CardConfiguration extends Configuration {
 
@@ -21,6 +24,9 @@ public class CardConfiguration extends Configuration {
 
     @NotNull
     private Integer graphitePort;
+
+    @JsonProperty("ecsContainerMetadataUriV4")
+    private URI ecsContainerMetadataUriV4;
 
     public URL getDiscoverDataLocation() {
         return discoverDataLocation;
@@ -40,5 +46,9 @@ public class CardConfiguration extends Configuration {
 
     public Integer getGraphitePort() {
         return graphitePort;
+    }
+
+    public Optional<URI> getEcsContainerMetadataUriV4() {
+        return Optional.ofNullable(ecsContainerMetadataUriV4);
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -35,3 +35,5 @@ testCardDataLocation: ${TEST_CARD_DATA_LOCATION:-file:///app/data/test-cards/tes
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
+
+ecsContainerMetadataUriV4: ${ECS_CONTAINER_METADATA_URI_V4:-}


### PR DESCRIPTION
Set up a prometheus metric endpoint /metrics.
Append ECS metadata info (via the PrometheusDefaultLabelSampleBuilder class in pay-java-commons) as default labels.

Analogus to https://github.com/alphagov/pay-connector/pull/4625, which has been tested.