### PR TITLE
PP-11154: Update initialise prometheus metrics

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -5,4 +5,8 @@ set -e
 cd "$(dirname "$0")"
 
 mvn -DskipTests clean package
-docker build -t govukpay/cardid:local .
+if [ "$(uname -m)" == "arm64" ]; then
+  docker build -t governmentdigitalservice/pay-cardid:local -f m1/arm64.Dockerfile .
+else
+  docker build -t governmentdigitalservice/pay-cardid:local .
+fi


### PR DESCRIPTION
## WHAT YOU DID
Now we don't need to build our default labels in the app (since they are now added by the sidecar) we should remove the default sample builder.

1. Remove default sample builder
2. Update local build script to account for m1 macs, and use the correct container tag

## How to test

This change has already been rolled out to connector and is working well.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [X] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
