### PR TITLE
PP-11407: Update docker image JRE to 11.0.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:aea6ff5a31148a9dc80c65fad592d5681c61f73dab8ad2f5b8fb08de256899dc
+FROM eclipse-temurin:11-jre-alpine@sha256:77f7c2509dba2f346bf042e424d395b16b0c432ee1eabf0cbcc17922dc900c73
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "--no-cache", "add", "tini"]

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre@sha256:3efc210202a0aa206aa353f7d31b36d24aa239251d6a30bdc3c25016f280c1bd
+FROM eclipse-temurin:11-jre@sha256:e12585f95f18fba9841aa3c12e6e4261f74b608cbc27b0fab61ac267b57de8f6
 
 RUN ["apt-get", "update"]
 RUN ["apt-get", "install", "-y", "tini"]


### PR DESCRIPTION
## WHAT YOU DID
Amended  'Dockerfile and 'm1/arm64.Dockerfile' with updated JRE docker image 11.0.20

## How to test

- Make sure the build succeeds
- Peer reviewed as part of pairing
- Another team member to review
- Smoke test relevant app or service

### Documentation

Refer to Jira ticket https://payments-platform.atlassian.net/browse/PP-11407 for version upgrade details.