### PR TITLE
PP-11990: Run apt-get upgrade for m1 containers

### DIFF
--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -8,6 +8,7 @@ RUN ["mvn", "clean", "--no-transfer-progress", "package", "-DskipTests"]
 FROM eclipse-temurin:11-jre@sha256:cfba8df9620f10a0e8b6a147a9a1a09dfce2477a9cb4552dfe94bc7319aa3032 AS final
 
 RUN ["apt-get", "update"]
+RUN ["apt-get", "upgrade", "-y"]
 RUN ["apt-get", "install", "-y", "tini"]
 
 ARG DNS_TTL=15


### PR DESCRIPTION
## WHAT YOU DID
Run apt-get upgrade for m1 containers (which are ubuntu, not alpine, until we get to java 21)
