### PR TITLE
PP-12240: Card length validation matches CARD_RANGE_LENGTH

### DIFF
--- a/src/main/java/uk/gov/pay/card/model/CardInformationRequest.java
+++ b/src/main/java/uk/gov/pay/card/model/CardInformationRequest.java
@@ -6,6 +6,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 
 import static java.lang.String.format;
+import static uk.gov.pay.card.db.CardInformationStore.CARD_RANGE_LENGTH;
 
 public class CardInformationRequest {
 
@@ -13,7 +14,7 @@ public class CardInformationRequest {
      * PANs can be between 10 and 19 characters
      * @see <a href="https://www.ansi.org/news_publications/news_story?articleid=da7bcb04-0654-4e03-af54-0e55d50b93a8">ANSI IIN</a>
      */
-    @JsonProperty("cardNumber") @NotEmpty @Size(min = 10, max = 19)
+    @JsonProperty("cardNumber") @NotEmpty @Size(min = CARD_RANGE_LENGTH, max = 19)
     private String cardNumber;
 
     public String getCardNumber() {

--- a/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
+++ b/src/test/java/uk/gov/pay/card/it/resources/CardIdResourceITest.java
@@ -6,6 +6,8 @@ import io.restassured.response.ValidatableResponse;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.pay.card.app.CardApi;
 import uk.gov.pay.card.app.config.CardConfiguration;
 
@@ -70,17 +72,10 @@ public class CardIdResourceITest {
                 .body("corporate", is(false));
     }
 
-    @Test
-    public void shouldErrorWhenShortCardNumberProvided() {
-        getCardInformation(buildCardNumberFromPrefixAndLength("2221", CARD_RANGE_LENGTH - 2))
-                .statusCode(422)
-                .contentType(JSON)
-                .body("errors[0]", is(String.format("cardNumber size must be between %s and 19", CARD_RANGE_LENGTH)));
-    }
-
-    @Test
-    public void shouldErrorWhenOneCharTooShortCardNumberProvided() {
-        getCardInformation(buildCardNumberFromPrefixAndLength("2221", CARD_RANGE_LENGTH - 1))
+    @ParameterizedTest
+    @ValueSource(ints = {CARD_RANGE_LENGTH - 2, CARD_RANGE_LENGTH - 1})
+    public void shouldErrorWhenShortCardNumberProvided(int length) {
+        getCardInformation(buildCardNumberFromPrefixAndLength("2221", length))
                 .statusCode(422)
                 .contentType(JSON)
                 .body("errors[0]", is(String.format("cardNumber size must be between %s and 19", CARD_RANGE_LENGTH)));


### PR DESCRIPTION
## WHAT YOU DID
I used `CARD_RANGE_LENGTH` to define the minimum length for the card number as any card number shorter than this leads to a 404 even if the range is correct.

## How to test

- Pick a bin range from a CSV that's shorter than the maximum (currently 11) (e.g. `71221111` from src/test/resources/card-id-resource-integration-test/test-bin-ranges.csv)
- Make requests with different numbers of zeros on the end of the prefix e.g. `71221111`, then `712211110`, then `7122111100`

Expectation: The first requests should give validation failures (`422` status code), then when they pass validation they should be found (`200` status code), if you continue to make them longer you'll reach another validation failure (`422` status code).

Current reality: The first requests should give validation failures (`422` status code), then when they pass validation then when you reach 10 characters it will pass validation but fail to find the card (`404` status code), then adding one more zero leads to it being found (`200` status code), if you continue to make them longer you'll reach another validation failure (`422` status code).

## Code review checklist

### Logging

- [ ] No logging has been added as the validation already existed, it's just been updated

### Documentation

- [ ] No changes to the documentation as it already explains about updating the `CARD_RANGE_LENGTH` and already implies that no other change is needed - with this PR no other change is needed (AFAICT).