### PR TITLE
BAU add dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
       # to go back to using an unmodified version
     versions:
     - ">= 4"
+  - dependency-name: "au.com.dius.pact.provider:junit5"
+    # Pact-JVM 4.6.x requires Java 17
+    versions:
+      - ">= 4.6"
   open-pull-requests-limit: 10
   labels:
   - dependencies


### PR DESCRIPTION
## WHAT YOU DID

pact jvm 4.6 requires Java 17. We are running on Java 11. Ignore updates that require Java higher than version 11.
