### PR TITLE
PP-12111 match `trigger-release` perms with called workflow

### DIFF
--- a/.github/workflows/ci-trigger-release.yml
+++ b/.github/workflows/ci-trigger-release.yml
@@ -12,4 +12,6 @@ jobs:
 
   trigger_release:
     needs: authorised_user_check
+    permissions:
+      contents: write
     uses: ./.github/workflows/post-merge.yml


### PR DESCRIPTION
## WHAT YOU DID

- a called workflow can't have higher permissions than the caller