### PR TITLE
PP-12111 pass pact auth secrets to called workflow

### DIFF
--- a/.github/workflows/ci-trigger-release.yml
+++ b/.github/workflows/ci-trigger-release.yml
@@ -15,3 +15,6 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/post-merge.yml
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}


### PR DESCRIPTION
## WHAT YOU DID

- pass pact broker auth secrets to called workflows in `ci-trigger-release`
