### PR TITLE
PP-12111 require pact secrets when `post-merge` is called

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -2,6 +2,11 @@ name: Post Merge
 
 on:
   workflow_call:
+    secrets:
+      pact_broker_username:
+        required: true
+      pact_broker_password:
+        required: true
   push:
     branches:
       - master


### PR DESCRIPTION
## WHAT YOU DID

- when `post-merge` is called by another workflow, require that pact broker secrets are passed
