### PR TITLE
PP-12571 Make post-merge workflow reusable workflow

### DIFF
--- a/.github/workflows/ci-trigger-release.yml
+++ b/.github/workflows/ci-trigger-release.yml
@@ -1,3 +1,4 @@
+# Workflow triggered by Concourse for new BIN ranges
 name: Trigger release
 
 on:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,6 +1,12 @@
 name: Post Merge
 
 on:
+  workflow_call:
+    secrets:
+      pact_broker_username:
+        required: true
+      pact_broker_password:
+        required: true
   push:
     branches:
       - master


### PR DESCRIPTION
## WHAT YOU DID
- Makes post-merge workflow a reusable one as it is being called by ci-trigger-release workflow
