### PR TITLE
PP-12687: Add Dependency Review workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,3 +12,7 @@ jobs:
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/pay-ci/.github/workflows/_run-dependency-review.yml@master


### PR DESCRIPTION
Adds the new [dependency review workflow](https://github.com/alphagov/pay-ci/pull/1329) to pre-merge checks.