### PR TITLE
BAU bump dropwizard version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>4.0.13</version>
+                <version>4.0.15</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## WHAT YOU DID

Dependabot is not bumping dropwizard-dependencies. Manual intervention is required.

Bump dropwizard-dependencies to version 4.0.15.

