### PR TITLE
PP-15420 remove Jetty pinning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>12.1.9</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
                 <version>5.0.2</version>


### PR DESCRIPTION
## WHAT YOU DID

We have pinned jetty bom’s because DW 5.0.1 had undesired versions (ITHC scan).

The DW 5.0.2 upgrade includes jetty 12.1.9.
Remove the pinned jetty dependencies.
