### PR TITLE
PP-15698: bump pay-java-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>uk.gov.pay</groupId>
-    <version>0.1-SNAPSHOT</version>
     <artifactId>pay-cardid</artifactId>
+    <version>0.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -31,7 +33,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <!-- Main dependencies that are imported from one of the BOMs specified
              in <dependencyManagement> so no explicit versions needed -->
@@ -294,6 +295,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>default</id>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>3.0</hamcrest.version>
         <jmh.version>1.37</jmh.version>
-        <pay-java-commons.version>1.0.20260727084644</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20260812081959</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <surefire.version>3.5.6</surefire.version>
         <pact.version>4.7.3</pact.version>


### PR DESCRIPTION
Bumps `pay-java-commons` to the latest version. This version removes the transitive `io.dropwizard.metrics:metrics-graphite` dependency. That dependency is not used here.

Additionally:
* Run `mvn tidy:pom`